### PR TITLE
feat(pages): Allow a subset of pages to be converted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IntelliJ IDEA files
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ test(`Convert PDF To PNG`, async () => {
         useSystemFonts: false, // When `true`, fonts that aren't embedded in the PDF document will fallback to a system font.
         viewportScale: 2.0, // The desired scale of PNG viewport
         outputFilesFolder: 'output/folder', // folder to write output png files,
-        pdfFilePassword: 'password', // password for encrypted PDF
+        pdfFilePassword: 'password', // password for encrypted PDF,
+        pages: [1, 3, 11]   // Subset of pages to convert (first page = 1, optional)
     });
 
    ...

--- a/__tests__/pdf.pages.to.file.ts
+++ b/__tests__/pdf.pages.to.file.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import comparePng from 'png-visual-compare';
+import { pdfToPng } from '../src';
+import { PngPageOutput } from '../src/convert.to.png';
+
+test(`Convert specific pages To PNG and save results to files`, async () => {
+  const pdfFilePath: string = resolve('test-data/large_pdf.pdf');
+  const pngPages: PngPageOutput[] = await pdfToPng(pdfFilePath, {
+    outputFilesFolder: 'test-results/pdf.pages.to.file/actual',
+    pages: [2, 5, 7, 99]
+  });
+
+  // Should skip page 99 since it's beyond PDF bounds
+  expect(pngPages).toHaveLength(3);
+
+  pngPages.forEach((pngPage: PngPageOutput) => {
+    const expectedFilePath: string = resolve('test-data/pdf.to.file/expected', pngPage.name);
+    const expectedFileContent: Buffer = readFileSync(expectedFilePath);
+    const actualFileContent: Buffer = readFileSync(pngPage.path);
+    const compareResult: number = comparePng(actualFileContent, expectedFileContent);
+
+    expect(compareResult).toBe(0);
+  });
+});

--- a/__tests__/pdf.to.png.exceptions.ts
+++ b/__tests__/pdf.to.png.exceptions.ts
@@ -13,3 +13,10 @@ test(`Should throw "outputFileMask is required when input is a Buffer" exception
 
     await expect(async() => { await pdfToPng(pdfFileBuffer) }).rejects.toThrow(Error);
 });
+
+test(`Should throw error when page index < 1 is requested`, async () => {
+    const pdfFilePath: string = resolve('test-data/large_pdf.pdf');
+
+    await expect(async() => { await pdfToPng(pdfFilePath, { pages: [0, 1, 2]}) }).rejects.toThrow('Invalid pages requested');
+    await expect(async() => { await pdfToPng(pdfFilePath, { pages: [1, 2, -1]}) }).rejects.toThrow('Invalid pages requested');
+});


### PR DESCRIPTION
Allow a user to specify an (optional) subset of page numbers to convert. This will allow for more efficient use of this project in use cases like:
* Generate a thumbnail of the PDF (only need page 1)
* Skip a known page number that is unneeded or contains sensitive data

Default behavior is unchanged - if no pages prop is provided the code will iterate over all pdf pages.

I chose to ignore the situation where a user could request a page beyond the PDF bounds (eg, request page 10 when there are only 9 pages in the PDF). There are scenarios where the developer might not have total knowledge of the input PDF (like if it's coming from a CMS) and they just want to generate PNGs for the first 1/5/etc pages - this behavior allows for graceful behavior in that scenario.


- [X] README Updated
- [X] Added tests