### PR TITLE
FEATURE: Added a method to get the document info without/before conversion 

### DIFF
--- a/__tests__/pdf.document.info.test.ts
+++ b/__tests__/pdf.document.info.test.ts
@@ -1,0 +1,54 @@
+import { resolve } from 'node:path'
+import { expect, test } from 'vitest'
+import { getPdfDocumentInfo, PdfDocumentInfo } from '../src'
+
+test('should get PDF document info without conversion', async () => {
+    const pdfFilePath: string = resolve('./test-data/sample.pdf')
+    const docInfo: PdfDocumentInfo = await getPdfDocumentInfo(pdfFilePath, {
+        viewportScale: 1.0,
+    })
+
+    expect(docInfo.numPages).to.equal(2)
+    expect(docInfo.pages).to.have.length(2)
+    
+    // Check first page
+    expect(docInfo.pages[0].pageNumber).to.equal(1)
+    expect(docInfo.pages[0].width).to.be.greaterThan(0)
+    expect(docInfo.pages[0].height).to.be.greaterThan(0)
+    expect(docInfo.pages[0].rotation).to.be.a('number')
+    
+    // Check second page
+    expect(docInfo.pages[1].pageNumber).to.equal(2)
+    expect(docInfo.pages[1].width).to.be.greaterThan(0)
+    expect(docInfo.pages[1].height).to.be.greaterThan(0)
+    expect(docInfo.pages[1].rotation).to.be.a('number')
+})
+
+test('should get PDF document info with custom viewport scale', async () => {
+    const pdfFilePath: string = resolve('./test-data/sample.pdf')
+    const docInfo1x: PdfDocumentInfo = await getPdfDocumentInfo(pdfFilePath, {
+        viewportScale: 1.0,
+    })
+    const docInfo2x: PdfDocumentInfo = await getPdfDocumentInfo(pdfFilePath, {
+        viewportScale: 2.0,
+    })
+
+    expect(docInfo1x.numPages).to.equal(docInfo2x.numPages)
+    
+    // 2x scale should have dimensions approximately 2x larger
+    expect(docInfo2x.pages[0].width).to.be.approximately(docInfo1x.pages[0].width * 2, 1)
+    expect(docInfo2x.pages[0].height).to.be.approximately(docInfo1x.pages[0].height * 2, 1)
+})
+
+test('should get PDF document info from buffer', async () => {
+    const { readFileSync } = await import('node:fs')
+    const pdfFilePath: string = resolve('./test-data/sample.pdf')
+    const pdfBuffer: ArrayBufferLike = readFileSync(pdfFilePath)
+    
+    const docInfo: PdfDocumentInfo = await getPdfDocumentInfo(pdfBuffer)
+
+    expect(docInfo.numPages).to.equal(2)
+    expect(docInfo.pages).to.have.length(2)
+    expect(docInfo.pages[0].width).to.be.greaterThan(0)
+    expect(docInfo.pages[0].height).to.be.greaterThan(0)
+}) 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export { pdfToPng } from './pdfToPng';
-export * from './types';
+export { pdfToPng, getPdfDocumentInfo, getPdfDocument } from './pdfToPng'
+export type { PdfDocumentInfo } from './pdfToPng'
+export * from './types'


### PR DESCRIPTION
Heyo 👋 

I am trying to convert PDFs to an optimal size in a single shot. 
I noticed there wasn't a way to get PDF document dimensions without performing the full conversion,
so I've added getPdfDocumentInfo.

## What this PR adds
- `getPdfDocumentInfo` function that extracts document metadata without conversion
- `PdfDocumentInfo` type definition for the return value
- Tests

## Example usage
```typescript
const docInfo = await getPdfDocumentInfo('/path/to/file.pdf', {
  viewportScale: 2.0
});
console.log(`Document has ${docInfo.numPages} pages`);
console.log(`First page: ${docInfo.pages[0].width}×${docInfo.pages[0].height}px`);
```

Thanks for the library! 