### PR TITLE
ci: migrate from self-hosted to GitHub-hosted runners

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   publish:
     if: ${{ !github.event.release.prerelease }}
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ permissions:
     contents: read
 jobs:
     ubuntu:
-        runs-on: [self-hosted, linux]
+        runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
             - name: Checkout


### PR DESCRIPTION
## Summary

- Replace `[self-hosted, linux]` with `ubuntu-latest` in both `test.yml` and `publish.yml`
- Removes dependency on self-hosted runner infrastructure

## Test plan

- [ ] Verify the test workflow triggers and passes on a push/PR
- [ ] Verify the publish workflow triggers correctly on a release event