### PR TITLE
security: harden against TOCTOU + OOM DoS (SEC-001/002/003)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -324,3 +324,91 @@ This backlog captures architectural, typing, maintainability, reliability, perfo
     2. `npm run build:strict` runs without a script error (exit 0 or `|| true`).
     3. `.github/workflows/test.yml` includes the `build:strict` step.
     4. `npm test` passes unchanged.
+
+---
+
+## Security Findings (Post-v4.0.0 CTF Hunt)
+
+> CTF-style vulnerability findings discovered after the v4.0.0 release. Each item below is unshipped and uses the same agent-execution rules as the items above.
+
+### [x] SEC-001 Reject path-separator characters in resolved page names (close TOCTOU on intermediate directories)
+
+- **Severity:** High in multi-tenant / co-tenant write contexts; Low for single-user CLI usage.
+- **Problem:** `outputFileMaskFunc` is a user-supplied callback whose returned filename flows through `resolvePageName()` (`src/pageOrchestrator.ts:15`) directly into `savePNGfile()` (`src/outputWriter.ts:18`). The containment check in `outputWriter.ts` is:
+    1. `isAbsolute(name)` — rejects absolute paths.
+    2. `relative(resolvedOutputFolder, join(resolvedOutputFolder, name))` — rejects strings that escape upward via `..`.
+    3. `fsPromises.realpath(dirname(resolvedFilePath))` — informational realpath of the **parent directory** of the target file.
+    4. `fsPromises.realpath(resolvedOutputFolder)` re-check — only verifies the **top-level** output folder is still the expected real path.
+    5. `fsPromises.open(resolvedFilePath, 'wx')` — the `'wx'` flag prevents overwriting an existing target, but `open()` still follows symlinks present in **intermediate** path components.
+       When `name` contains a path separator (e.g. an attacker-controlled `outputFileMaskFunc` returning `"sub/page.png"`, or any consumer who legitimately wants subdirectory output), step 4 does not cover the intermediate `sub/` component. Between step 3's `realpath(dirname)` and step 5's `open()`, a co-tenant or attacker with write access to `resolvedOutputFolder` can swap `sub` for a symlink pointing outside the output folder. The write then lands at an attacker-chosen path. The `savePNGfile` JSDoc explicitly admits this: _"A residual TOCTOU window still exists for directory-component swaps."_
+- **Technical rationale:** The library currently accepts `name` strings that contain path separators (POSIX `/`, Windows `\`) without rejecting them, even though the containment guarantee only holds for **flat** filenames (no separators). Closing this gap by rejecting separators in `name` eliminates the entire TOCTOU class for intermediate directories — without requiring `openat()` (which Node.js does not expose directly). It also matches the de facto contract of the existing tests in `__tests__/path.traversal.test.ts`, which only cover flat filenames.
+- **Reproducer (conceptual):**
+    1. Two-user shared output folder `/shared/out` (mode `0777`).
+    2. Victim calls `pdfToPng('doc.pdf', { outputFolder: '/shared/out', outputFileMaskFunc: () => 'sub/page.png' })` after attacker creates `/shared/out/sub` as a real directory.
+    3. Attacker runs a tight loop: `unlink('/shared/out/sub'); symlink('/etc/cron.d', '/shared/out/sub')`.
+    4. Eventually the swap wins the race between `realpath(dirname(...))` and `open(..., 'wx')`. Write lands at `/etc/cron.d/page.png`.
+- **Implementation direction:**
+    1. In `src/pageOrchestrator.ts`, modify `resolvePageName` so that, after either the default-mask or the `outputFileMaskFunc` branch produces `name`, it throws `Error('outputFileMaskFunc returned a filename containing a path separator: <name>')` when `name` contains any of `/`, `\\`, or `path.sep` (use `/[\\\\\\/]/.test(name)`).
+    2. Add the same guard at the top of `src/outputWriter.ts:savePNGfile` (defense in depth — `savePNGfile` is also `export`ed and reachable via the `FilesystemSink`).
+    3. Update the JSDoc on `savePNGfile` to remove the _"residual TOCTOU"_ admission and replace it with a one-line statement that `name` must be a flat filename (no separators).
+- **Acceptance criteria:**
+    1. `resolvePageName(1, 'doc', () => 'sub/page.png')` throws synchronously.
+    2. `resolvePageName(1, 'doc', () => 'sub\\\\page.png')` throws synchronously (Windows separator rejected on all platforms).
+    3. `resolvePageName(1, 'doc', () => 'page.png')` returns `'page.png'` unchanged.
+    4. `savePNGfile('sub/page.png', Buffer.from([]), '/tmp/out', '/tmp/out')` throws synchronously before any filesystem call.
+    5. A new test row is added to `__tests__/path.traversal.test.ts` asserting the rejection for both POSIX and Windows separators.
+    6. All existing tests in `__tests__/path.traversal.test.ts` and `__tests__/security.path.test.ts` still pass unchanged.
+    7. `npm test`, `npm run build:test`, and `npm run lint` pass.
+
+### [x] SEC-002 Bound input PDF size to prevent OOM denial-of-service
+
+- **Severity:** High in service / multi-tenant contexts where `pdfFile` paths or buffers originate from untrusted callers; N/A for trusted local CLI usage.
+- **Problem:** `getPdfFileBuffer()` (`src/pdfInput.ts:5`) reads the entire input via `await fsPromises.readFile(pdfFile)` with no size cap. On Linux, passing `'/dev/zero'` (or a sparse multi-TB file, or a fifo backed by a streaming producer) consumes memory until the Node.js process is OOM-killed. There is also no `maxInputBytes` validation on the `ArrayBufferLike | Uint8Array` branch — a caller (or upstream untrusted source feeding a buffer) can supply an arbitrarily large buffer that pdfjs will then attempt to parse, multiplying memory pressure. The existing `MAX_VIEWPORT_SCALE` and `MAX_CANVAS_PIXELS` guards (`src/const.ts:8,14`) cap rendering memory but not parsing memory.
+- **Technical rationale:** OOM on a long-running Node service is a clean DoS — restart costs cascade, in-flight requests die, and on Kubernetes the pod is killed and rescheduled. A pre-read `stat()` is essentially free compared to a `readFile()` of an unbounded path, and rejecting oversized buffers in the buffer branch is a single length check.
+- **Reproducer (Linux):**
+    ```ts
+    await pdfToPng('/dev/zero'); // Process RSS climbs until OOM-killer fires.
+    ```
+    ```ts
+    await pdfToPng(new Uint8Array(2 ** 31 - 1)); // ~2 GiB buffer, pdfjs parses garbage.
+    ```
+- **Implementation direction:**
+    1. Add `MAX_INPUT_BYTES = 256 * 1024 * 1024` (256 MiB) to `src/const.ts` with a JSDoc explaining the rationale (a generous bound for legitimate PDFs while keeping a single conversion below typical container memory limits).
+    2. Extend `PdfToPngOptions` (`src/interfaces/pdf.to.png.options.ts`) with `maxInputBytes?: number` — optional override capped at `Number.MAX_SAFE_INTEGER`. Document it in JSDoc and in `README.md`.
+    3. In `src/normalizePdfToPngOptions.ts`, add validation: throw `Error('maxInputBytes must be a positive integer')` for non-integer or `<= 0` values. Default to `MAX_INPUT_BYTES`.
+    4. In `src/pdfInput.ts`, before `fsPromises.readFile`, call `await fsPromises.stat(pdfFile)` on the path branch and throw `Error(\`Input PDF exceeds maxInputBytes (\${stats.size} > \${maxInputBytes})\`)`if`stats.size > maxInputBytes`. Also reject when `stats.isFile() === false`(this fails closed for`/dev/zero`, fifos, sockets, and directories, all of which have `isFile() === false` on Linux).
+    5. On the buffer branch (`Buffer.isBuffer`, `ArrayBufferLike`, `Uint8Array`), throw the same error when `byteLength > maxInputBytes`.
+    6. Update `getPdfFileBuffer()` to accept `maxInputBytes` as a parameter; `pdfToPng()` passes the normalized value through.
+- **Acceptance criteria:**
+    1. `pdfToPng('/dev/zero')` rejects synchronously with the "exceeds maxInputBytes" error (or "not a regular file" error) — does NOT hang or grow memory unboundedly. Verified by a test using `vi.mock('node:fs')` to simulate `stat` returning `{ size: Infinity, isFile: () => false }`.
+    2. `pdfToPng(new Uint8Array(MAX_INPUT_BYTES + 1))` rejects synchronously with the same error.
+    3. `pdfToPng('test-data/sample.pdf', { maxInputBytes: 100 })` rejects (sample.pdf is larger than 100 bytes).
+    4. `pdfToPng('test-data/sample.pdf', { maxInputBytes: 100 * 1024 * 1024 })` succeeds.
+    5. `normalizePdfToPngOptions({ maxInputBytes: 0 })` and `normalizePdfToPngOptions({ maxInputBytes: -1 })` throw.
+    6. A new test file `__tests__/input.size.limit.test.ts` covers each case above.
+    7. `npm test`, `npm run build:test`, and `npm run lint` pass.
+
+### [x] SEC-003 Cap `concurrencyLimit` upper bound to prevent canvas-allocation OOM
+
+- **Severity:** High in service / multi-tenant contexts where `PdfToPngOptions` and the input PDF originate from untrusted callers; Low for trusted local CLI usage.
+- **Problem:** `normalizePdfToPngOptions()` validates only the **lower** bound of `concurrencyLimit` (`src/normalizePdfToPngOptions.ts:47-50`): `if (processPagesInParallel && (!Number.isInteger(concurrencyLimit) || concurrencyLimit < 1))` — any positive integer is accepted, up to `Number.MAX_SAFE_INTEGER`. The sliding-window scheduler then spawns `Math.min(concurrencyLimit, pageNumbers.length)` workers (`src/pdfToPng.ts:35`), so for a multi-page document the worker count grows linearly with the smaller of the two. Each worker allocates a canvas whose area is bounded by `MAX_CANVAS_PIXELS = 100_000_000` (~400 MB of raw bitmap memory at 4 bytes/pixel, per `src/const.ts:14`). The per-page guard in `renderPdfPage()` (`src/pageRenderer.ts:61`) protects against a single oversized canvas, but it does **not** protect against many simultaneous canvases.
+- **Technical rationale:** With both knobs attacker-controlled, peak memory ≈ `min(concurrencyLimit, pages) × MAX_CANVAS_PIXELS × 4 bytes`. Upload a 1000-page PDF with modest per-page dimensions, set `processPagesInParallel: true, concurrencyLimit: 1000`, and the process attempts ~400 GB of bitmap allocations — far above any realistic container memory limit, triggering immediate OOM. Even at moderate values (`concurrencyLimit: 64`, full-bleed pages near the pixel cap), peak memory ≈ 25 GB, well above typical service limits. Capping `concurrencyLimit` to a sane upper bound is a one-line validation change; the default `4` is unaffected.
+- **Reproducer (conceptual):**
+    ```ts
+    // Attacker uploads a 500-page PDF with full-bleed-near-cap pages, then:
+    await pdfToPng(attackerPdf, { processPagesInParallel: true, concurrencyLimit: 500 });
+    // Process RSS spikes; OOM-killer fires before any page completes.
+    ```
+- **Implementation direction:**
+    1. Add `MAX_CONCURRENCY_LIMIT = 16` to `src/const.ts` with a JSDoc explaining the bound: peak memory at this cap ≈ `16 × 400 MB = 6.4 GB`, which is a defensible ceiling for typical Node.js service containers and still allows realistic parallelism.
+    2. In `src/normalizePdfToPngOptions.ts`, extend the existing validation block (lines 47–50) to also reject values `> MAX_CONCURRENCY_LIMIT`: throw `Error(\`concurrencyLimit must be between 1 and \${MAX_CONCURRENCY_LIMIT}, received: \${concurrencyLimit}\`)`.
+    3. Apply the cap **only when `processPagesInParallel === true`** to preserve the documented default behavior of `concurrencyLimit: 4` for sequential mode (where the value is effectively unused).
+    4. Update the JSDoc for `concurrencyLimit` in `src/interfaces/pdf.to.png.options.ts` (lines 116–124) to document the upper bound and its rationale.
+    5. Update `README.md` to document the cap.
+- **Acceptance criteria:**
+    1. `pdfToPng('test-data/sample.pdf', { processPagesInParallel: true, concurrencyLimit: 17 })` throws synchronously with the new bounded error message.
+    2. `pdfToPng('test-data/sample.pdf', { processPagesInParallel: true, concurrencyLimit: 16 })` succeeds.
+    3. `pdfToPng('test-data/sample.pdf', { processPagesInParallel: true, concurrencyLimit: Number.MAX_SAFE_INTEGER })` throws synchronously — no canvas is ever allocated.
+    4. `pdfToPng('test-data/sample.pdf')` (sequential default) still succeeds with no impact from this cap.
+    5. The existing test `__tests__/pdf.to.png.concurrency.limit.validation.test.ts` is extended with three new cases: `concurrencyLimit: MAX_CONCURRENCY_LIMIT` (passes), `concurrencyLimit: MAX_CONCURRENCY_LIMIT + 1` (throws), `concurrencyLimit: Number.MAX_SAFE_INTEGER` with `processPagesInParallel: true` (throws).
+    6. `npm test`, `npm run build:test`, and `npm run lint` pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **SEC-001**: `outputFileMaskFunc` filenames are now rejected synchronously when they contain a `/` or `\` path separator, closing a residual TOCTOU window where a co-tenant with write access to `outputFolder` could swap an intermediate directory for a symlink between the `realpath(dirname(...))` check and the `open(..., 'wx')` call in `savePNGfile()`. The guard fires both in `resolvePageName` (early) and in `savePNGfile` (defense in depth). The existing flat-filename contract is unchanged.
+- **SEC-002**: Added `PdfToPngOptions.maxInputBytes` (default `256 MiB` via `MAX_INPUT_BYTES`) bounding input PDF size. The path branch of `getPdfFileBuffer()` now runs `fs.stat()` before `fs.readFile()` and rejects (a) non-regular files (`/dev/zero`, FIFOs, sockets, character devices) and (b) inputs whose size exceeds `maxInputBytes`. The buffer / `Uint8Array` branch validates `byteLength` against the same cap. Together these block unbounded memory consumption from untrusted input paths and oversized buffers.
+- **SEC-003**: `concurrencyLimit` now enforces an upper bound of `MAX_CONCURRENCY_LIMIT` (`16`) when `processPagesInParallel` is `true`. At the cap, peak in-flight canvas memory ≈ `16 × MAX_CANVAS_PIXELS × 4 bytes ≈ 6.4 GiB` — a defensible ceiling for typical service containers. Values above `16` (e.g. `Number.MAX_SAFE_INTEGER`) throw synchronously before any rendering starts. The default `4` and lower values are unaffected.
+
 ### Changed
 
 - CI now blocks on `npm run build:strict`; the strict type-check is no longer advisory. `continue-on-error: true` is removed from `.github/workflows/test.yml` and the dedicated CI "Strict type check" step is replaced by `pretest` gating (avoiding a double run on CI). `pretest` now runs `build:strict` alongside `build:test` — the two type-checks enforce different contracts: `build:test` (using `tsconfig.json`, no DOM lib) gates `src/` against accidental DOM globals (`document`, `window`) that production builds would reject; `build:strict` (using `tsconfig.strict.json`, `skipLibCheck: false` + DOM lib for `@napi-rs/canvas` type resolution) gates against upstream type regressions in `pdfjs-dist` / `@napi-rs/canvas`. Local `npm test` and `prepublishOnly` now gate on both.

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.0.0"
   },
-  "sourceHash": "4a4b7d835e7866fdda1b58e05d0a68f0bda1de784750172e8de5ce46e2e6589e",
+  "sourceHash": "8ed7ee7ec5b19109f755267603004b55084fb5a24708d87c483ef7a21a23a74b",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -220,30 +220,44 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
           "signature": "export const MAX_CANVAS_PIXELS = 100_000_000"
         },
         {
+          "name": "MAX_INPUT_BYTES",
+          "kind": "variable",
+          "line": 23,
+          "exported": true,
+          "signature": "export const MAX_INPUT_BYTES = 256 * 1024 * 1024"
+        },
+        {
+          "name": "MAX_CONCURRENCY_LIMIT",
+          "kind": "variable",
+          "line": 31,
+          "exported": true,
+          "signature": "export const MAX_CONCURRENCY_LIMIT = 16"
+        },
+        {
           "name": "PDF_TO_PNG_OPTIONS_DEFAULTS",
           "kind": "variable",
-          "line": 20,
+          "line": 37,
           "exported": true,
           "signature": "export const PDF_TO_PNG_OPTIONS_DEFAULTS = { viewportScale: 1, disableFontFace: true, useSystemFonts: false, enableXfa: true, outputFileMask: 'buffer', pdfFilePassword: undefined, concurrencyLimit: 4,…"
         },
         {
           "name": "CMAP_RELATIVE_URL",
           "kind": "variable",
-          "line": 38,
+          "line": 55,
           "exported": true,
           "signature": "export const CMAP_RELATIVE_URL = './node_modules/pdfjs-dist/cmaps/'"
         },
         {
           "name": "STANDARD_FONTS_RELATIVE_URL",
           "kind": "variable",
-          "line": 39,
+          "line": 56,
           "exported": true,
           "signature": "export const STANDARD_FONTS_RELATIVE_URL = './node_modules/pdfjs-dist/standard_fonts/'"
         },
         {
           "name": "DOCUMENT_INIT_PARAMS_DEFAULTS",
           "kind": "variable",
-          "line": 51,
+          "line": 68,
           "exported": true,
           "signature": "export const DOCUMENT_INIT_PARAMS_DEFAULTS: DocumentInitParameters = { cMapUrl: CMAP_RELATIVE_URL, cMapPacked: true, standardFontDataUrl: STANDARD_FONTS_RELATIVE_URL, }"
         }
@@ -558,7 +572,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "normalizePdfToPngOptions",
           "kind": "function",
-          "line": 21,
+          "line": 22,
           "exported": true,
           "signature": "export function normalizePdfToPngOptions(props: PdfToPngOptions | undefined): NormalizedPdfToPngOptions"
         }
@@ -567,6 +581,8 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "from": "./const.js",
           "names": [
+            "MAX_CONCURRENCY_LIMIT",
+            "MAX_INPUT_BYTES",
             "MAX_VIEWPORT_SCALE",
             "PDF_TO_PNG_OPTIONS_DEFAULTS"
           ]
@@ -618,16 +634,23 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
       "path": "src/outputWriter.ts",
       "symbols": [
         {
+          "name": "PATH_SEPARATOR_PATTERN",
+          "kind": "variable",
+          "line": 4,
+          "exported": false,
+          "signature": "const PATH_SEPARATOR_PATTERN = /[\\\\/]/"
+        },
+        {
           "name": "isEscapingRelativePath",
           "kind": "function",
-          "line": 3,
+          "line": 6,
           "exported": false,
           "signature": "function isEscapingRelativePath(rel: string): boolean"
         },
         {
           "name": "savePNGfile",
           "kind": "function",
-          "line": 18,
+          "line": 22,
           "exported": true,
           "signature": "export async function savePNGfile(name: string, content: Buffer, resolvedOutputFolder: string, realOutputFolder: string): Promise<string>"
         }
@@ -656,16 +679,30 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
       "path": "src/pageOrchestrator.ts",
       "symbols": [
         {
+          "name": "PATH_SEPARATOR_PATTERN",
+          "kind": "variable",
+          "line": 6,
+          "exported": false,
+          "signature": "const PATH_SEPARATOR_PATTERN = /[\\\\/]/"
+        },
+        {
+          "name": "assertFlatFilename",
+          "kind": "function",
+          "line": 8,
+          "exported": false,
+          "signature": "function assertFlatFilename(name: string, pageNumber: number): void"
+        },
+        {
           "name": "resolvePageName",
           "kind": "function",
-          "line": 6,
+          "line": 16,
           "exported": true,
           "signature": "export function resolvePageName( pageNumber: number, defaultMask: string, outputFileMaskFunc: ((page: number) => string) | undefined, ): string"
         },
         {
           "name": "processAndSavePage",
           "kind": "function",
-          "line": 25,
+          "line": 37,
           "exported": true,
           "signature": "export async function processAndSavePage( pdfDocument: PDFDocumentProxy, pageName: string, pageNumber: number, pageViewportScale: number, shouldReturnContent: boolean, returnMetadataOnly: boolean, out…"
         }
@@ -766,11 +803,18 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
       "path": "src/pdfInput.ts",
       "symbols": [
         {
-          "name": "getPdfFileBuffer",
+          "name": "rejectOversized",
           "kind": "function",
           "line": 3,
+          "exported": false,
+          "signature": "function rejectOversized(byteLength: number, maxInputBytes: number): void"
+        },
+        {
+          "name": "getPdfFileBuffer",
+          "kind": "function",
+          "line": 9,
           "exported": true,
-          "signature": "export async function getPdfFileBuffer(pdfFile: string | ArrayBufferLike | Uint8Array): Promise<Uint8Array | ArrayBufferLike>"
+          "signature": "export async function getPdfFileBuffer( pdfFile: string | ArrayBufferLike | Uint8Array, maxInputBytes: number, ): Promise<Uint8Array | ArrayBufferLike>"
         }
       ],
       "imports": [

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.0.0"
   },
-  "sourceHash": "8ed7ee7ec5b19109f755267603004b55084fb5a24708d87c483ef7a21a23a74b",
+  "sourceHash": "81d018f58055fe9747d759262b47d3f222cc51242edb1158947773eaaaf2dc7b",
   "entrypoints": [
     "src/index.ts"
   ],

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.0.0"
   },
-  "sourceHash": "f2d7efe3d0f5442c5d4d5b39d057e52069da1219fda341c8908211717fe80c88",
+  "sourceHash": "738ffcbc35ad19fc804eaef774f10e2f4074a917c2c2f8026683e64838992dbe",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -656,7 +656,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "savePNGfile",
           "kind": "function",
-          "line": 27,
+          "line": 29,
           "exported": true,
           "signature": "export async function savePNGfile(name: string, content: Buffer, resolvedOutputFolder: string, realOutputFolder: string): Promise<string>"
         }

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.0.0"
   },
-  "sourceHash": "81d018f58055fe9747d759262b47d3f222cc51242edb1158947773eaaaf2dc7b",
+  "sourceHash": "f2d7efe3d0f5442c5d4d5b39d057e52069da1219fda341c8908211717fe80c88",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -243,21 +243,21 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "CMAP_RELATIVE_URL",
           "kind": "variable",
-          "line": 55,
+          "line": 56,
           "exported": true,
           "signature": "export const CMAP_RELATIVE_URL = './node_modules/pdfjs-dist/cmaps/'"
         },
         {
           "name": "STANDARD_FONTS_RELATIVE_URL",
           "kind": "variable",
-          "line": 56,
+          "line": 57,
           "exported": true,
           "signature": "export const STANDARD_FONTS_RELATIVE_URL = './node_modules/pdfjs-dist/standard_fonts/'"
         },
         {
           "name": "DOCUMENT_INIT_PARAMS_DEFAULTS",
           "kind": "variable",
-          "line": 68,
+          "line": 69,
           "exported": true,
           "signature": "export const DOCUMENT_INIT_PARAMS_DEFAULTS: DocumentInitParameters = { cMapUrl: CMAP_RELATIVE_URL, cMapPacked: true, standardFontDataUrl: STANDARD_FONTS_RELATIVE_URL, }"
         }
@@ -582,7 +582,6 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
           "from": "./const.js",
           "names": [
             "MAX_CONCURRENCY_LIMIT",
-            "MAX_INPUT_BYTES",
             "MAX_VIEWPORT_SCALE",
             "PDF_TO_PNG_OPTIONS_DEFAULTS"
           ]
@@ -636,21 +635,28 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "PATH_SEPARATOR_PATTERN",
           "kind": "variable",
-          "line": 4,
+          "line": 8,
           "exported": false,
-          "signature": "const PATH_SEPARATOR_PATTERN = /[\\\\/]/"
+          "signature": "const PATH_SEPARATOR_PATTERN = sep === '\\\\' ? /[\\\\/]/ : /\\"
+        },
+        {
+          "name": "SEPARATOR_DESCRIPTION",
+          "kind": "variable",
+          "line": 9,
+          "exported": false,
+          "signature": "const SEPARATOR_DESCRIPTION = sep === '\\\\' ? '\"/\" or \"\\\\\"' : '\"/\"'"
         },
         {
           "name": "isEscapingRelativePath",
           "kind": "function",
-          "line": 6,
+          "line": 11,
           "exported": false,
           "signature": "function isEscapingRelativePath(rel: string): boolean"
         },
         {
           "name": "savePNGfile",
           "kind": "function",
-          "line": 22,
+          "line": 27,
           "exported": true,
           "signature": "export async function savePNGfile(name: string, content: Buffer, resolvedOutputFolder: string, realOutputFolder: string): Promise<string>"
         }
@@ -681,28 +687,35 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "PATH_SEPARATOR_PATTERN",
           "kind": "variable",
-          "line": 6,
+          "line": 11,
           "exported": false,
-          "signature": "const PATH_SEPARATOR_PATTERN = /[\\\\/]/"
+          "signature": "const PATH_SEPARATOR_PATTERN = sep === '\\\\' ? /[\\\\/]/ : /\\"
+        },
+        {
+          "name": "SEPARATOR_DESCRIPTION",
+          "kind": "variable",
+          "line": 12,
+          "exported": false,
+          "signature": "const SEPARATOR_DESCRIPTION = sep === '\\\\' ? '\"/\" or \"\\\\\"' : '\"/\"'"
         },
         {
           "name": "assertFlatFilename",
           "kind": "function",
-          "line": 8,
+          "line": 14,
           "exported": false,
           "signature": "function assertFlatFilename(name: string, pageNumber: number): void"
         },
         {
           "name": "resolvePageName",
           "kind": "function",
-          "line": 16,
+          "line": 22,
           "exported": true,
           "signature": "export function resolvePageName( pageNumber: number, defaultMask: string, outputFileMaskFunc: ((page: number) => string) | undefined, ): string"
         },
         {
           "name": "processAndSavePage",
           "kind": "function",
-          "line": 37,
+          "line": 43,
           "exported": true,
           "signature": "export async function processAndSavePage( pdfDocument: PDFDocumentProxy, pageName: string, pageNumber: number, pageViewportScale: number, shouldReturnContent: boolean, returnMetadataOnly: boolean, out…"
         }
@@ -726,6 +739,12 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
           "names": [
             "getPageMetadata",
             "renderPdfPage"
+          ]
+        },
+        {
+          "from": "node:path",
+          "names": [
+            "sep"
           ]
         },
         {

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Converts PDF pages to PNG images.
     // Output Options
     outputFolder?: string,           // Directory to save PNG files
     outputFileMaskFunc?: (pageNumber: number) => string, // Custom filename function
+                                     // Must return a flat filename — names containing "/" or "\"
+                                     // path separators are rejected synchronously.
 
     // Rendering Options
     viewportScale?: number,          // PNG scale/zoom level (default: 1.0, max: 100)
@@ -166,12 +168,17 @@ Converts PDF pages to PNG images.
 
     // Security
     pdfFilePassword?: string,        // Password for encrypted PDFs
+    maxInputBytes?: number,          // Max input PDF size in bytes (default: 256 * 1024 * 1024)
+                                     // Path inputs are stat()'d before reading and non-regular files
+                                     // (FIFOs, sockets, /dev/zero) are rejected. Buffer / Uint8Array
+                                     // inputs are validated against the same cap by byteLength.
 
     // Processing
     pagesToProcess?: number[],       // 1-indexed integer pages to convert (e.g., [1, 3, 5])
                                     // Non-integer and <= 0 values throw; pages beyond the PDF length are ignored
     processPagesInParallel?: boolean, // Enable parallel processing (default: false)
-    concurrencyLimit?: number,       // Max concurrent pages, positive integer (default: 4)
+    concurrencyLimit?: number,       // Max concurrent pages when parallel: integer 1..16 (default: 4)
+                                     // The upper bound caps peak in-flight canvas memory at ~6.4 GiB.
 
     // Output Control
     returnPageContent?: boolean,     // Include PNG buffer in output (default: true)

--- a/__tests__/coverage.test.ts
+++ b/__tests__/coverage.test.ts
@@ -14,12 +14,15 @@ vi.mock('node:fs', () => ({
             close: vi.fn().mockResolvedValue(undefined),
         }),
         realpath: vi.fn(),
+        stat: vi.fn(),
     },
 }));
 
 vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
     getDocument: vi.fn(),
 }));
+
+const defaultStat = { size: 8, isFile: (): boolean => true } as Awaited<ReturnType<typeof fsPromises.stat>>;
 
 beforeEach(() => {
     (fsPromises.readFile as Mock).mockReset();
@@ -29,6 +32,7 @@ beforeEach(() => {
         close: vi.fn().mockResolvedValue(undefined),
     });
     (fsPromises.realpath as Mock).mockReset();
+    (fsPromises.stat as Mock).mockReset().mockResolvedValue(defaultStat);
     (getDocument as Mock).mockReset();
 });
 

--- a/__tests__/input.size.limit.test.ts
+++ b/__tests__/input.size.limit.test.ts
@@ -71,3 +71,18 @@ test('getPdfFileBuffer rejects a buffer one byte above maxInputBytes', async () 
     const input = new Uint8Array(9);
     await expect(getPdfFileBuffer(input, 8)).rejects.toThrow(/exceeds maxInputBytes/);
 });
+
+test('getPdfFileBuffer rejects when the file grows between stat() and readFile() (TOCTOU)', async () => {
+    // Pre-check sees a 100-byte file (passes), but readFile() returns a 1 KiB buffer —
+    // simulating an attacker growing the file between the two syscalls. The post-read
+    // re-check must reject the oversized payload.
+    vi.spyOn(fsPromises, 'stat').mockResolvedValueOnce({
+        size: 100,
+        isFile: (): boolean => true,
+    } as Awaited<ReturnType<typeof fsPromises.stat>>);
+    (vi.spyOn(fsPromises, 'readFile') as unknown as { mockResolvedValueOnce: (value: unknown) => unknown }).mockResolvedValueOnce(
+        Buffer.alloc(1024),
+    );
+
+    await expect(getPdfFileBuffer('/pretend/grew-mid-read.pdf', 512)).rejects.toThrow(/exceeds maxInputBytes/);
+});

--- a/__tests__/input.size.limit.test.ts
+++ b/__tests__/input.size.limit.test.ts
@@ -1,0 +1,73 @@
+import { promises as fsPromises } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { MAX_INPUT_BYTES } from '../src/const';
+import { getPdfFileBuffer } from '../src/pdfInput';
+import { pdfToPng } from '../src/pdfToPng';
+
+const SAMPLE_PDF = resolve('./test-data/sample.pdf');
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+test('pdfToPng rejects a path-based input larger than maxInputBytes before reading', async () => {
+    await expect(pdfToPng(SAMPLE_PDF, { maxInputBytes: 100 })).rejects.toThrow(/exceeds maxInputBytes/);
+});
+
+test('pdfToPng accepts a path-based input within maxInputBytes', async () => {
+    await expect(
+        pdfToPng(SAMPLE_PDF, { maxInputBytes: MAX_INPUT_BYTES, returnMetadataOnly: true, pagesToProcess: [1] }),
+    ).resolves.toHaveLength(1);
+});
+
+test('pdfToPng rejects a Uint8Array input larger than maxInputBytes', async () => {
+    const oversized = new Uint8Array(1024);
+    await expect(pdfToPng(oversized, { maxInputBytes: 100 })).rejects.toThrow(/exceeds maxInputBytes/);
+});
+
+test('pdfToPng rejects a Buffer input larger than maxInputBytes', async () => {
+    const oversized = Buffer.alloc(1024);
+    await expect(pdfToPng(oversized, { maxInputBytes: 100 })).rejects.toThrow(/exceeds maxInputBytes/);
+});
+
+test('getPdfFileBuffer rejects a path whose stat() reports it is not a regular file', async () => {
+    const fakePath = '/dev/zero';
+    vi.spyOn(fsPromises, 'stat').mockResolvedValueOnce({
+        size: 0,
+        isFile: (): boolean => false,
+    } as Awaited<ReturnType<typeof fsPromises.stat>>);
+
+    await expect(getPdfFileBuffer(fakePath, MAX_INPUT_BYTES)).rejects.toThrow(/not a regular file/);
+});
+
+test('getPdfFileBuffer rejects a path whose stat() reports size above maxInputBytes', async () => {
+    const fakePath = join(tmpdir(), 'pretend-huge.pdf');
+    vi.spyOn(fsPromises, 'stat').mockResolvedValueOnce({
+        size: MAX_INPUT_BYTES + 1,
+        isFile: (): boolean => true,
+    } as Awaited<ReturnType<typeof fsPromises.stat>>);
+
+    await expect(getPdfFileBuffer(fakePath, MAX_INPUT_BYTES)).rejects.toThrow(/exceeds maxInputBytes/);
+});
+
+test('getPdfFileBuffer reads a path within the size cap', async () => {
+    const buffer = await getPdfFileBuffer(SAMPLE_PDF, MAX_INPUT_BYTES);
+    expect(buffer.byteLength).toBeGreaterThan(0);
+});
+
+test('getPdfFileBuffer accepts a buffer at exactly maxInputBytes', async () => {
+    const input = new Uint8Array(8);
+    const result = await getPdfFileBuffer(input, 8);
+    expect(result.byteLength).toBe(8);
+});
+
+test('getPdfFileBuffer rejects a buffer one byte above maxInputBytes', async () => {
+    const input = new Uint8Array(9);
+    await expect(getPdfFileBuffer(input, 8)).rejects.toThrow(/exceeds maxInputBytes/);
+});

--- a/__tests__/normalize.pdf.to.png.options.test.ts
+++ b/__tests__/normalize.pdf.to.png.options.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { MAX_CONCURRENCY_LIMIT, MAX_INPUT_BYTES } from '../src/const';
 import type { PdfToPngOptions } from '../src/interfaces/pdf.to.png.options.js';
 import { normalizePdfToPngOptions } from '../src/normalizePdfToPngOptions';
 
@@ -17,6 +18,7 @@ test('should apply defaults when options are undefined', () => {
         returnMetadataOnly: false,
         processPagesInParallel: false,
         concurrencyLimit: 4,
+        maxInputBytes: MAX_INPUT_BYTES,
     });
 });
 
@@ -38,6 +40,7 @@ test('should preserve explicitly provided happy-path values', () => {
             returnMetadataOnly: true,
             processPagesInParallel: true,
             concurrencyLimit: 2,
+            maxInputBytes: 1024,
         }),
     ).toEqual({
         viewportScale: 2,
@@ -53,7 +56,32 @@ test('should preserve explicitly provided happy-path values', () => {
         returnMetadataOnly: true,
         processPagesInParallel: true,
         concurrencyLimit: 2,
+        maxInputBytes: 1024,
     });
+});
+
+test('should reject concurrencyLimit values above MAX_CONCURRENCY_LIMIT when parallel is enabled', () => {
+    expect(() => normalizePdfToPngOptions({ processPagesInParallel: true, concurrencyLimit: MAX_CONCURRENCY_LIMIT + 1 })).toThrow(
+        `concurrencyLimit must be between 1 and ${MAX_CONCURRENCY_LIMIT}`,
+    );
+    expect(() => normalizePdfToPngOptions({ processPagesInParallel: true, concurrencyLimit: Number.MAX_SAFE_INTEGER })).toThrow(
+        `concurrencyLimit must be between 1 and ${MAX_CONCURRENCY_LIMIT}`,
+    );
+});
+
+test('should allow concurrencyLimit equal to MAX_CONCURRENCY_LIMIT', () => {
+    expect(() => normalizePdfToPngOptions({ processPagesInParallel: true, concurrencyLimit: MAX_CONCURRENCY_LIMIT })).not.toThrow();
+});
+
+test('should ignore concurrencyLimit upper bound when parallel mode is disabled', () => {
+    expect(() => normalizePdfToPngOptions({ concurrencyLimit: Number.MAX_SAFE_INTEGER })).not.toThrow();
+});
+
+test('should reject non-positive or non-integer maxInputBytes', () => {
+    expect(() => normalizePdfToPngOptions({ maxInputBytes: 0 })).toThrow('maxInputBytes must be a positive integer');
+    expect(() => normalizePdfToPngOptions({ maxInputBytes: -1 })).toThrow('maxInputBytes must be a positive integer');
+    expect(() => normalizePdfToPngOptions({ maxInputBytes: 1.5 })).toThrow('maxInputBytes must be a positive integer');
+    expect(() => normalizePdfToPngOptions({ maxInputBytes: Number.NaN })).toThrow('maxInputBytes must be a positive integer');
 });
 
 test('should reject an empty outputFolder before any I/O', () => {

--- a/__tests__/path.traversal.test.ts
+++ b/__tests__/path.traversal.test.ts
@@ -1,9 +1,11 @@
 import { promises as fsPromises } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 import { expect, test } from 'vitest';
 import { resolvePageName } from '../src/pageOrchestrator';
 import { savePNGfile } from '../src/outputWriter';
 import { pdfToPng } from '../src';
+
+const isWindows = sep === '\\';
 
 const pdfFilePath: string = resolve('./test-data/sample.pdf');
 const outputFolder: string = './test-results/path-traversal-guard';
@@ -60,27 +62,33 @@ test('should accept outputFileMaskFunc returning a safe filename', async () => {
     }
 });
 
-test('resolvePageName should reject names containing a POSIX path separator', () => {
+test('resolvePageName should reject names containing the platform path separator "/"', () => {
     expect(() => resolvePageName(1, 'sample', () => 'sub/page.png')).toThrow('path separator');
 });
 
-test('resolvePageName should reject names containing a Windows path separator on every platform', () => {
+test.runIf(isWindows)('resolvePageName should reject "\\" on Windows where it is a path separator', () => {
     expect(() => resolvePageName(1, 'sample', () => 'sub\\page.png')).toThrow('path separator');
+});
+
+test.skipIf(isWindows)('resolvePageName should accept "\\" on POSIX where it is a valid filename character', () => {
+    // PDFs named e.g. `foo\bar.pdf` produce a default mask of `foo\bar` via `path.parse(pdfFile).name`.
+    // The SEC-001 guard must not break that legitimate POSIX use case.
+    expect(resolvePageName(1, 'sample', () => 'foo\\bar.png')).toBe('foo\\bar.png');
 });
 
 test('resolvePageName should accept a flat filename unchanged', () => {
     expect(resolvePageName(1, 'sample', () => 'page.png')).toBe('page.png');
 });
 
-test('savePNGfile should reject a name containing a POSIX path separator before any I/O', async () => {
+test('savePNGfile should reject a name containing "/" before any I/O', async () => {
     await expect(savePNGfile('sub/page.png', Buffer.alloc(0), '/tmp/does-not-matter', '/tmp/does-not-matter')).rejects.toThrow(
-        'Output file name must be a flat filename without path separators',
+        /Output file name must be a flat filename without .* path separators/,
     );
 });
 
-test('savePNGfile should reject a name containing a Windows path separator before any I/O', async () => {
-    await expect(savePNGfile('sub\\page.png', Buffer.alloc(0), '/tmp/does-not-matter', '/tmp/does-not-matter')).rejects.toThrow(
-        'Output file name must be a flat filename without path separators',
+test.runIf(isWindows)('savePNGfile should reject "\\" on Windows before any I/O', async () => {
+    await expect(savePNGfile('sub\\page.png', Buffer.alloc(0), 'C:\\tmp', 'C:\\tmp')).rejects.toThrow(
+        /Output file name must be a flat filename without .* path separators/,
     );
 });
 
@@ -92,4 +100,24 @@ test('pdfToPng should reject outputFileMaskFunc returning a subdirectory filenam
             outputFileMaskFunc: () => 'sub/page.png',
         }),
     ).rejects.toThrow('path separator');
+});
+
+test.skipIf(isWindows)('pdfToPng should accept a PDF whose name contains "\\" on POSIX (default mask preserves the char)', async () => {
+    // Regression test for PR #142 review: ensure rejecting "\\" as a separator on every platform
+    // does not break POSIX conversions where `path.parse(pdfFile).name` legitimately contains "\".
+    const resolvedOutputFolder = resolve(outputFolder);
+    await fsPromises.rm(resolvedOutputFolder, { recursive: true, force: true });
+    await fsPromises.mkdir(resolvedOutputFolder, { recursive: true });
+    // Create a copy of sample.pdf at a path whose basename contains "\" on POSIX.
+    const tricky = resolve(resolvedOutputFolder, 'foo\\bar.pdf');
+    await fsPromises.copyFile(pdfFilePath, tricky);
+
+    const pngPages = await pdfToPng(tricky, {
+        outputFolder,
+        returnPageContent: false,
+        pagesToProcess: [1],
+    });
+    expect(pngPages).toHaveLength(1);
+    expect(pngPages[0].path).toContain('foo\\bar');
+    expect(pngPages[0].path.startsWith(resolvedOutputFolder)).toBe(true);
 });

--- a/__tests__/path.traversal.test.ts
+++ b/__tests__/path.traversal.test.ts
@@ -1,6 +1,8 @@
 import { promises as fsPromises } from 'node:fs';
 import { resolve } from 'node:path';
 import { expect, test } from 'vitest';
+import { resolvePageName } from '../src/pageOrchestrator';
+import { savePNGfile } from '../src/outputWriter';
 import { pdfToPng } from '../src';
 
 const pdfFilePath: string = resolve('./test-data/sample.pdf');
@@ -13,7 +15,7 @@ test('should reject outputFileMaskFunc returning a path-traversal filename', asy
             outputFolder,
             outputFileMaskFunc: () => '../../evil.png',
         }),
-    ).rejects.toThrow('Output file name escapes the output folder');
+    ).rejects.toThrow(/path separator|escapes the output folder/);
 });
 
 test('should reject outputFileMaskFunc returning an absolute path outside outputFolder', async () => {
@@ -24,7 +26,7 @@ test('should reject outputFileMaskFunc returning an absolute path outside output
             outputFolder,
             outputFileMaskFunc: () => absolutePathOutside,
         }),
-    ).rejects.toThrow('Output file name escapes the output folder');
+    ).rejects.toThrow(/path separator|escapes the output folder/);
 });
 
 test('should accept outputFileMaskFunc returning a filename starting with .. (not a traversal)', async () => {
@@ -56,4 +58,38 @@ test('should accept outputFileMaskFunc returning a safe filename', async () => {
         expect(pngPage.path).toContain('safe_page_');
         expect(pngPage.path.startsWith(resolvedOutputFolder)).toBe(true);
     }
+});
+
+test('resolvePageName should reject names containing a POSIX path separator', () => {
+    expect(() => resolvePageName(1, 'sample', () => 'sub/page.png')).toThrow('path separator');
+});
+
+test('resolvePageName should reject names containing a Windows path separator on every platform', () => {
+    expect(() => resolvePageName(1, 'sample', () => 'sub\\page.png')).toThrow('path separator');
+});
+
+test('resolvePageName should accept a flat filename unchanged', () => {
+    expect(resolvePageName(1, 'sample', () => 'page.png')).toBe('page.png');
+});
+
+test('savePNGfile should reject a name containing a POSIX path separator before any I/O', async () => {
+    await expect(savePNGfile('sub/page.png', Buffer.alloc(0), '/tmp/does-not-matter', '/tmp/does-not-matter')).rejects.toThrow(
+        'Output file name must be a flat filename without path separators',
+    );
+});
+
+test('savePNGfile should reject a name containing a Windows path separator before any I/O', async () => {
+    await expect(savePNGfile('sub\\page.png', Buffer.alloc(0), '/tmp/does-not-matter', '/tmp/does-not-matter')).rejects.toThrow(
+        'Output file name must be a flat filename without path separators',
+    );
+});
+
+test('pdfToPng should reject outputFileMaskFunc returning a subdirectory filename', async () => {
+    await fsPromises.rm(resolve(outputFolder), { recursive: true, force: true });
+    await expect(
+        pdfToPng(pdfFilePath, {
+            outputFolder,
+            outputFileMaskFunc: () => 'sub/page.png',
+        }),
+    ).rejects.toThrow('path separator');
 });

--- a/__tests__/pdf.to.png.buffer.readfile.test.ts
+++ b/__tests__/pdf.to.png.buffer.readfile.test.ts
@@ -9,6 +9,7 @@ vi.mock('node:fs', () => ({
         mkdir: vi.fn(),
         writeFile: vi.fn(),
         realpath: vi.fn(),
+        stat: vi.fn().mockResolvedValue({ size: 1024, isFile: (): boolean => true }),
     },
 }));
 

--- a/__tests__/pdf.to.png.concurrency.limit.validation.test.ts
+++ b/__tests__/pdf.to.png.concurrency.limit.validation.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { MAX_CONCURRENCY_LIMIT } from '../src/const';
 import { pdfToPng } from '../src/pdfToPng';
 
 describe('pdfToPng concurrencyLimit validation', () => {
@@ -75,15 +76,44 @@ describe('pdfToPng concurrencyLimit validation', () => {
     });
 
     it('should return all pages when concurrencyLimit exceeds the page count', async () => {
-        // concurrencyLimit: 100 on a 2-page PDF — entire PDF fits in a single batch
+        // concurrencyLimit at the upper cap on a 2-page PDF — entire PDF fits in a single batch
         const result = await pdfToPng(pdfFilePath, {
             processPagesInParallel: true,
-            concurrencyLimit: 100,
+            concurrencyLimit: MAX_CONCURRENCY_LIMIT,
             returnMetadataOnly: true,
         });
         expect(result.length).toBe(2); // sample.pdf has 2 pages
         expect(result[0].pageNumber).toBe(1);
         expect(result[1].pageNumber).toBe(2);
+    });
+
+    it('should throw when concurrencyLimit exceeds MAX_CONCURRENCY_LIMIT', async () => {
+        await expect(
+            pdfToPng(pdfFilePath, {
+                processPagesInParallel: true,
+                concurrencyLimit: MAX_CONCURRENCY_LIMIT + 1,
+            }),
+        ).rejects.toThrow(`concurrencyLimit must be between 1 and ${MAX_CONCURRENCY_LIMIT}`);
+    });
+
+    it('should throw when concurrencyLimit is Number.MAX_SAFE_INTEGER', async () => {
+        await expect(
+            pdfToPng(pdfFilePath, {
+                processPagesInParallel: true,
+                concurrencyLimit: Number.MAX_SAFE_INTEGER,
+            }),
+        ).rejects.toThrow(`concurrencyLimit must be between 1 and ${MAX_CONCURRENCY_LIMIT}`);
+    });
+
+    it('should accept concurrencyLimit equal to MAX_CONCURRENCY_LIMIT', async () => {
+        const result = await pdfToPng(pdfFilePath, {
+            processPagesInParallel: true,
+            concurrencyLimit: MAX_CONCURRENCY_LIMIT,
+            returnMetadataOnly: true,
+            pagesToProcess: [1],
+        });
+        expect(result.length).toBe(1);
+        expect(result[0].pageNumber).toBe(1);
     });
 
     it('should return one page when processPagesInParallel is true with a single page requested', async () => {

--- a/__tests__/security.path.test.ts
+++ b/__tests__/security.path.test.ts
@@ -38,7 +38,7 @@ test('should reject outputFileMaskFunc values that escape the output folder via 
                 pagesToProcess: [1],
                 returnPageContent: false,
             }),
-        ).rejects.toThrow('Output file name escapes the output folder');
+        ).rejects.toThrow(/path separator|escapes the output folder/);
     } finally {
         await fsPromises.rm(outputFolder, { recursive: true, force: true });
     }
@@ -55,7 +55,7 @@ test('should reject absolute outputFileMaskFunc values', async () => {
                 pagesToProcess: [1],
                 returnPageContent: false,
             }),
-        ).rejects.toThrow('Output file name escapes the output folder');
+        ).rejects.toThrow(/path separator|escapes the output folder/);
     } finally {
         await fsPromises.rm(outputFolder, { recursive: true, force: true });
     }

--- a/src/const.ts
+++ b/src/const.ts
@@ -43,6 +43,7 @@ export const PDF_TO_PNG_OPTIONS_DEFAULTS = {
     outputFileMask: 'buffer',
     pdfFilePassword: undefined,
     concurrencyLimit: 4,
+    maxInputBytes: MAX_INPUT_BYTES,
 };
 
 /**

--- a/src/const.ts
+++ b/src/const.ts
@@ -14,6 +14,23 @@ export const MAX_VIEWPORT_SCALE = 100;
 export const MAX_CANVAS_PIXELS = 100_000_000;
 
 /**
+ * Default upper bound on input PDF size in bytes. 256 MiB is a generous ceiling for legitimate
+ * PDFs while keeping a single conversion well below typical service container memory limits.
+ * The path branch of `getPdfFileBuffer()` runs `stat()` before `readFile()` so this also blocks
+ * unbounded reads from `/dev/zero`, FIFOs, sockets, and other non-regular files.
+ * Callers can override with `PdfToPngOptions.maxInputBytes`.
+ */
+export const MAX_INPUT_BYTES = 256 * 1024 * 1024;
+
+/**
+ * Upper bound on `concurrencyLimit` when `processPagesInParallel` is `true`. At this cap,
+ * peak in-flight canvas memory ≈ `16 × MAX_CANVAS_PIXELS × 4 bytes` ≈ 6.4 GiB, which is a
+ * defensible ceiling for typical Node.js service containers while still allowing realistic
+ * parallelism. Higher values would let a single conversion exhaust container memory.
+ */
+export const MAX_CONCURRENCY_LIMIT = 16;
+
+/**
  * Default values applied to `PdfToPngOptions` fields that are not explicitly set by the caller.
  * These are also used as the source of truth for documented defaults in JSDoc comments on the type.
  */

--- a/src/interfaces/pdf.to.png.options.ts
+++ b/src/interfaces/pdf.to.png.options.ts
@@ -50,13 +50,12 @@ export interface PdfToPngOptions {
      * When omitted, no files are written to disk.
      *
      * @remarks
-     * **Security (TOCTOU):** The write-containment guard resolves symlinks, checks that the
-     * output path stays within this folder, and uses exclusive-create file opens to avoid
-     * overwriting pre-existing files or following a pre-planted target symlink at the final filename.
-     * A residual race window still exists for directory-component swaps. A local attacker could exploit this via
-     * (a) atomically replacing the folder with a symlink during that window, or (b) creating or
-     * pre-populating an unsafe directory layout inside this folder before the containment checks run.
-     * To reduce exposure on multi-user or shared systems, ensure this directory is private and not writable by untrusted users.
+     * **Security (TOCTOU):** The write-containment guard rejects filenames that contain path
+     * separators (so the target is always a direct child of this folder), resolves symlinks,
+     * checks that the output path stays within this folder, and uses exclusive-create file opens
+     * to avoid overwriting pre-existing files or following a pre-planted target symlink at the
+     * final filename. To reduce exposure on multi-user or shared systems, ensure this directory
+     * is private and not writable by untrusted users.
      */
     outputFolder?: string;
 
@@ -115,11 +114,24 @@ export interface PdfToPngOptions {
 
     /**
      * Maximum number of pages rendered simultaneously when `processPagesInParallel` is `true`.
-     * Must be a positive integer (`>= 1`). Non-integer or sub-1 values throw immediately (before any I/O).
-     * Higher values increase throughput at the cost of memory.
-     * Only applies when `processPagesInParallel` is `true`.
+     * Must be a positive integer between `1` and `16` (inclusive); values outside that range throw
+     * immediately (before any I/O). The upper bound caps peak in-flight canvas memory at roughly
+     * `16 × MAX_CANVAS_PIXELS × 4 bytes ≈ 6.4 GiB` so a single conversion cannot exhaust container
+     * memory. Higher values increase throughput at the cost of memory. Only applies when
+     * `processPagesInParallel` is `true`.
      * Default: `4`.
      * @since 3.14.0
      */
     concurrencyLimit?: number;
+
+    /**
+     * Maximum allowed input PDF size in bytes. Inputs larger than this throw immediately,
+     * before any rendering work is started. Applies to both the file path branch (validated via
+     * `fs.stat()`) and the buffer / `Uint8Array` branch (validated via `byteLength`). The path
+     * branch additionally rejects non-regular files (FIFOs, sockets, character devices such as
+     * `/dev/zero`) to prevent unbounded reads. Must be a positive integer.
+     * Default: `256 * 1024 * 1024` (256 MiB).
+     * @since 4.1.0
+     */
+    maxInputBytes?: number;
 }

--- a/src/normalizePdfToPngOptions.ts
+++ b/src/normalizePdfToPngOptions.ts
@@ -1,4 +1,4 @@
-import { MAX_CONCURRENCY_LIMIT, MAX_INPUT_BYTES, MAX_VIEWPORT_SCALE, PDF_TO_PNG_OPTIONS_DEFAULTS } from './const.js';
+import { MAX_CONCURRENCY_LIMIT, MAX_VIEWPORT_SCALE, PDF_TO_PNG_OPTIONS_DEFAULTS } from './const.js';
 import type { PdfToPngOptions } from './interfaces/pdf.to.png.options.js';
 import { VerbosityLevel } from './types/verbosity.level.js';
 
@@ -55,7 +55,7 @@ export function normalizePdfToPngOptions(props: PdfToPngOptions | undefined): No
         }
     }
 
-    const maxInputBytes: number = props?.maxInputBytes ?? MAX_INPUT_BYTES;
+    const maxInputBytes: number = props?.maxInputBytes ?? PDF_TO_PNG_OPTIONS_DEFAULTS.maxInputBytes;
     if (!Number.isInteger(maxInputBytes) || maxInputBytes <= 0) {
         throw new Error(`maxInputBytes must be a positive integer, received: ${maxInputBytes}`);
     }

--- a/src/normalizePdfToPngOptions.ts
+++ b/src/normalizePdfToPngOptions.ts
@@ -1,4 +1,4 @@
-import { MAX_VIEWPORT_SCALE, PDF_TO_PNG_OPTIONS_DEFAULTS } from './const.js';
+import { MAX_CONCURRENCY_LIMIT, MAX_INPUT_BYTES, MAX_VIEWPORT_SCALE, PDF_TO_PNG_OPTIONS_DEFAULTS } from './const.js';
 import type { PdfToPngOptions } from './interfaces/pdf.to.png.options.js';
 import { VerbosityLevel } from './types/verbosity.level.js';
 
@@ -16,6 +16,7 @@ export interface NormalizedPdfToPngOptions {
     returnMetadataOnly: boolean;
     processPagesInParallel: boolean;
     concurrencyLimit: number;
+    maxInputBytes: number;
 }
 
 export function normalizePdfToPngOptions(props: PdfToPngOptions | undefined): NormalizedPdfToPngOptions {
@@ -45,8 +46,18 @@ export function normalizePdfToPngOptions(props: PdfToPngOptions | undefined): No
 
     const processPagesInParallel = props?.processPagesInParallel ?? false;
     const concurrencyLimit: number = props?.concurrencyLimit ?? PDF_TO_PNG_OPTIONS_DEFAULTS.concurrencyLimit;
-    if (processPagesInParallel && (!Number.isInteger(concurrencyLimit) || concurrencyLimit < 1)) {
-        throw new Error(`concurrencyLimit must be a positive integer >= 1, received: ${concurrencyLimit}`);
+    if (processPagesInParallel) {
+        if (!Number.isInteger(concurrencyLimit) || concurrencyLimit < 1) {
+            throw new Error(`concurrencyLimit must be a positive integer >= 1, received: ${concurrencyLimit}`);
+        }
+        if (concurrencyLimit > MAX_CONCURRENCY_LIMIT) {
+            throw new Error(`concurrencyLimit must be between 1 and ${MAX_CONCURRENCY_LIMIT}, received: ${concurrencyLimit}`);
+        }
+    }
+
+    const maxInputBytes: number = props?.maxInputBytes ?? MAX_INPUT_BYTES;
+    if (!Number.isInteger(maxInputBytes) || maxInputBytes <= 0) {
+        throw new Error(`maxInputBytes must be a positive integer, received: ${maxInputBytes}`);
     }
 
     return {
@@ -63,5 +74,6 @@ export function normalizePdfToPngOptions(props: PdfToPngOptions | undefined): No
         returnMetadataOnly: props?.returnMetadataOnly ?? false,
         processPagesInParallel,
         concurrencyLimit,
+        maxInputBytes,
     };
 }

--- a/src/outputWriter.ts
+++ b/src/outputWriter.ts
@@ -15,14 +15,16 @@ function isEscapingRelativePath(rel: string): boolean {
 /**
  * Writes a rendered PNG page to disk using an exclusive-create open (`'wx'`) and returns the final path.
  *
- * The `name` argument must be a flat filename containing no `/` or `\` characters; rejecting
- * separators here closes the TOCTOU window on intermediate directory components (an attacker
- * with write access to the output folder could otherwise swap a sub-directory for a symlink
- * between the realpath check and the `open()` call). The `'wx'` flag additionally prevents
- * overwriting an existing target and blocks following a pre-existing symlink at the target
- * filename on POSIX systems. Callers should clear the output folder before re-running the same
- * conversion if they expect to reuse the same output names. The input object is not mutated;
- * callers receive the resolved path from the return value.
+ * The `name` argument must be a flat filename containing no host path separators — `/` on
+ * POSIX, and both `/` and `\` on Windows. On POSIX, `\` is a valid filename character and is
+ * intentionally allowed (e.g. PDFs named `foo\bar.pdf` produce a default mask of `foo\bar`).
+ * Rejecting separators here closes the TOCTOU window on intermediate directory components (an
+ * attacker with write access to the output folder could otherwise swap a sub-directory for a
+ * symlink between the realpath check and the `open()` call). The `'wx'` flag additionally
+ * prevents overwriting an existing target and blocks following a pre-existing symlink at the
+ * target filename on POSIX systems. Callers should clear the output folder before re-running
+ * the same conversion if they expect to reuse the same output names. The input object is not
+ * mutated; callers receive the resolved path from the return value.
  */
 export async function savePNGfile(name: string, content: Buffer, resolvedOutputFolder: string, realOutputFolder: string): Promise<string> {
     if (PATH_SEPARATOR_PATTERN.test(name)) {

--- a/src/outputWriter.ts
+++ b/src/outputWriter.ts
@@ -1,5 +1,8 @@
 import { promises as fsPromises } from 'node:fs';
 import { dirname, isAbsolute, join, relative, sep } from 'node:path';
+
+const PATH_SEPARATOR_PATTERN = /[\\/]/;
+
 function isEscapingRelativePath(rel: string): boolean {
     return rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel);
 }
@@ -7,15 +10,20 @@ function isEscapingRelativePath(rel: string): boolean {
 /**
  * Writes a rendered PNG page to disk using an exclusive-create open (`'wx'`) and returns the final path.
  *
- * This prevents overwriting an existing file and blocks following a pre-existing symlink
- * at the target filename on POSIX systems. Callers should clear the output folder before
- * re-running the same conversion if they expect to reuse the same output names. The input
- * object is not mutated; callers receive the resolved path from the return value.
- *
- * A residual TOCTOU window still exists for directory-component swaps, so the containment
- * checks and final realpath re-check remain necessary.
+ * The `name` argument must be a flat filename containing no `/` or `\` characters; rejecting
+ * separators here closes the TOCTOU window on intermediate directory components (an attacker
+ * with write access to the output folder could otherwise swap a sub-directory for a symlink
+ * between the realpath check and the `open()` call). The `'wx'` flag additionally prevents
+ * overwriting an existing target and blocks following a pre-existing symlink at the target
+ * filename on POSIX systems. Callers should clear the output folder before re-running the same
+ * conversion if they expect to reuse the same output names. The input object is not mutated;
+ * callers receive the resolved path from the return value.
  */
 export async function savePNGfile(name: string, content: Buffer, resolvedOutputFolder: string, realOutputFolder: string): Promise<string> {
+    if (PATH_SEPARATOR_PATTERN.test(name)) {
+        throw new Error(`Output file name must be a flat filename without path separators: ${name}`);
+    }
+
     if (isAbsolute(name)) {
         throw new Error(`Output file name escapes the output folder: ${name}`);
     }

--- a/src/outputWriter.ts
+++ b/src/outputWriter.ts
@@ -1,7 +1,12 @@
 import { promises as fsPromises } from 'node:fs';
 import { dirname, isAbsolute, join, relative, sep } from 'node:path';
 
-const PATH_SEPARATOR_PATTERN = /[\\/]/;
+// Reject only characters the host OS treats as path separators. On POSIX, "\" is a valid
+// filename character (e.g. PDFs named `foo\bar.pdf` produce a default mask of `foo\bar`) so
+// rejecting it would break legitimate flat-filename conversions there. See SEC-001 in
+// CHANGELOG / BACKLOG for the threat model.
+const PATH_SEPARATOR_PATTERN = sep === '\\' ? /[\\/]/ : /\//;
+const SEPARATOR_DESCRIPTION = sep === '\\' ? '"/" or "\\"' : '"/"';
 
 function isEscapingRelativePath(rel: string): boolean {
     return rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel);
@@ -21,7 +26,7 @@ function isEscapingRelativePath(rel: string): boolean {
  */
 export async function savePNGfile(name: string, content: Buffer, resolvedOutputFolder: string, realOutputFolder: string): Promise<string> {
     if (PATH_SEPARATOR_PATTERN.test(name)) {
-        throw new Error(`Output file name must be a flat filename without path separators: ${name}`);
+        throw new Error(`Output file name must be a flat filename without ${SEPARATOR_DESCRIPTION} path separators: ${name}`);
     }
 
     if (isAbsolute(name)) {

--- a/src/pageOrchestrator.ts
+++ b/src/pageOrchestrator.ts
@@ -1,14 +1,20 @@
+import { sep } from 'node:path';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
 import type { FilePngPageOutput, PngPageOutput } from './interfaces/index.js';
 import type { OutputSink } from './interfaces/output.sink.js';
 import { getPageMetadata, renderPdfPage } from './pageRenderer.js';
 
-const PATH_SEPARATOR_PATTERN = /[\\/]/;
+// Reject only characters the host OS treats as path separators. On Windows both "\" and "/"
+// are separators; on POSIX only "/" is — "\" is a valid filename character there, so PDFs
+// such as `foo\bar.pdf` must still convert successfully when the library derives the default
+// page-name mask from `path.parse(pdfFile).name`.
+const PATH_SEPARATOR_PATTERN = sep === '\\' ? /[\\/]/ : /\//;
+const SEPARATOR_DESCRIPTION = sep === '\\' ? '"/" or "\\"' : '"/"';
 
 function assertFlatFilename(name: string, pageNumber: number): void {
     if (PATH_SEPARATOR_PATTERN.test(name)) {
         throw new Error(
-            `outputFileMaskFunc returned a filename containing a path separator for page ${pageNumber}: "${name}". The filename must be a flat name with no "/" or "\\" characters.`,
+            `outputFileMaskFunc returned a filename containing a path separator for page ${pageNumber}: "${name}". The filename must be a flat name with no ${SEPARATOR_DESCRIPTION} characters.`,
         );
     }
 }

--- a/src/pageOrchestrator.ts
+++ b/src/pageOrchestrator.ts
@@ -3,6 +3,16 @@ import type { FilePngPageOutput, PngPageOutput } from './interfaces/index.js';
 import type { OutputSink } from './interfaces/output.sink.js';
 import { getPageMetadata, renderPdfPage } from './pageRenderer.js';
 
+const PATH_SEPARATOR_PATTERN = /[\\/]/;
+
+function assertFlatFilename(name: string, pageNumber: number): void {
+    if (PATH_SEPARATOR_PATTERN.test(name)) {
+        throw new Error(
+            `outputFileMaskFunc returned a filename containing a path separator for page ${pageNumber}: "${name}". The filename must be a flat name with no "/" or "\\" characters.`,
+        );
+    }
+}
+
 export function resolvePageName(
     pageNumber: number,
     defaultMask: string,
@@ -18,6 +28,8 @@ export function resolvePageName(
             `outputFileMaskFunc returned an empty filename for page ${pageNumber}. Provide a non-empty string including the .png extension.`,
         );
     }
+
+    assertFlatFilename(name, pageNumber);
 
     return name;
 }

--- a/src/pdfInput.ts
+++ b/src/pdfInput.ts
@@ -1,7 +1,22 @@
 import { promises as fsPromises } from 'node:fs';
 
-export async function getPdfFileBuffer(pdfFile: string | ArrayBufferLike | Uint8Array): Promise<Uint8Array | ArrayBufferLike> {
+function rejectOversized(byteLength: number, maxInputBytes: number): void {
+    if (byteLength > maxInputBytes) {
+        throw new Error(`Input PDF exceeds maxInputBytes (${byteLength} > ${maxInputBytes} bytes)`);
+    }
+}
+
+export async function getPdfFileBuffer(
+    pdfFile: string | ArrayBufferLike | Uint8Array,
+    maxInputBytes: number,
+): Promise<Uint8Array | ArrayBufferLike> {
     if (typeof pdfFile === 'string') {
+        const stats = await fsPromises.stat(pdfFile);
+        if (!stats.isFile()) {
+            throw new Error(`Input PDF path is not a regular file: ${pdfFile}`);
+        }
+        rejectOversized(stats.size, maxInputBytes);
+
         const buffer = await fsPromises.readFile(pdfFile);
         if (buffer instanceof ArrayBuffer) {
             return buffer;
@@ -13,8 +28,10 @@ export async function getPdfFileBuffer(pdfFile: string | ArrayBufferLike | Uint8
     }
 
     if (Buffer.isBuffer(pdfFile)) {
+        rejectOversized(pdfFile.byteLength, maxInputBytes);
         return new Uint8Array(pdfFile);
     }
 
+    rejectOversized(pdfFile.byteLength, maxInputBytes);
     return pdfFile;
 }

--- a/src/pdfInput.ts
+++ b/src/pdfInput.ts
@@ -18,6 +18,10 @@ export async function getPdfFileBuffer(
         rejectOversized(stats.size, maxInputBytes);
 
         const buffer = await fsPromises.readFile(pdfFile);
+        // Post-read re-check: closes the TOCTOU window between stat() and readFile().
+        // If the file was replaced or grew between the two calls, the buffer may exceed
+        // maxInputBytes — reject it before it propagates further into pdfjs parsing.
+        rejectOversized(buffer.byteLength, maxInputBytes);
         if (buffer instanceof ArrayBuffer) {
             return buffer;
         }

--- a/src/pdfToPng.ts
+++ b/src/pdfToPng.ts
@@ -45,7 +45,7 @@ async function processPagesWithSlidingWindow<T>(
 export async function pdfToPng(pdfFile: string | ArrayBufferLike | Uint8Array, props?: PdfToPngOptions): Promise<PngPageOutput[]> {
     const normalizedProps = normalizePdfToPngOptions(props);
     const pageViewportScale = normalizedProps.viewportScale;
-    const pdfFileBuffer: Uint8Array | ArrayBufferLike = await getPdfFileBuffer(pdfFile);
+    const pdfFileBuffer: Uint8Array | ArrayBufferLike = await getPdfFileBuffer(pdfFile, normalizedProps.maxInputBytes);
     const pdfDocument: PDFDocumentProxy = await getPdfDocument(pdfFileBuffer, normalizedProps);
     const pagesToProcess: number[] =
         normalizedProps.pagesToProcess ?? Array.from({ length: pdfDocument.numPages }, (_, index) => index + 1);


### PR DESCRIPTION
## Summary

Three CTF-grade hardening fixes from the post-v4.0.0 security hunt (see `BACKLOG.md` → "Security Findings (Post-v4.0.0 CTF Hunt)").

- **SEC-001** — TOCTOU on intermediate directory components. Rejects `outputFileMaskFunc` names containing `/` or `\` so the target is always a direct child of `outputFolder`. Closes the residual race window admitted in the prior `savePNGfile()` JSDoc.
- **SEC-002** — Unbounded `fs.readFile()` on input PDFs. Adds `PdfToPngOptions.maxInputBytes` (default `256 MiB`). Path inputs are `stat()`'d before `readFile()` and non-regular files (`/dev/zero`, FIFOs, sockets) are rejected. Buffer / `Uint8Array` inputs validated against the same cap via `byteLength`.
- **SEC-003** — Unbounded `concurrencyLimit` upper end. Adds `MAX_CONCURRENCY_LIMIT = 16`. `normalizePdfToPngOptions` rejects values above the cap when `processPagesInParallel: true`. Caps peak in-flight canvas memory at ~6.4 GiB. Default (`4`) and below are unaffected.

## Threat model — who this protects

- Multi-tenant / co-tenant write to a shared `outputFolder` (SEC-001).
- Services that accept untrusted file paths or untrusted callers supplying `pdfFile` buffers (SEC-002, SEC-003).
- Trusted local CLI usage is **not** affected by the defaults; existing successful conversions remain successful.

## Files changed

| Layer | Files |
| --- | --- |
| Constants | `src/const.ts` (new `MAX_INPUT_BYTES`, `MAX_CONCURRENCY_LIMIT`) |
| Public option type | `src/interfaces/pdf.to.png.options.ts` (`maxInputBytes`, updated JSDoc for `concurrencyLimit` and `outputFolder`) |
| Validation | `src/normalizePdfToPngOptions.ts` (cap, integer check, `maxInputBytes` default + validation) |
| Input | `src/pdfInput.ts` (stat + size guard for path / buffer branches), `src/pdfToPng.ts` (wire `maxInputBytes`) |
| Output guard | `src/pageOrchestrator.ts`, `src/outputWriter.ts` (path-separator gate + JSDoc) |
| Docs | `CHANGELOG.md`, `README.md`, `BACKLOG.md` (SEC items marked `[x]`), `CODEMAP.md` (regenerated) |
| Tests | new `__tests__/input.size.limit.test.ts`; extended `path.traversal`, `security.path`, `normalize.pdf.to.png.options`, `pdf.to.png.concurrency.limit.validation`; mocked-fs tests extended with `stat` |

## Test plan

- [x] `npm run build:test` — clean
- [x] `npm run build:strict` — clean
- [x] `npm run lint` — clean
- [x] `npm run codemap:check` — up to date
- [x] `npm run test:license` — all licenses on allow-list
- [x] `npm test` (full coverage run) — 181 / 181 tests pass; coverage 97% lines, 100% functions, 94.6% branches (above the 85/90/90 thresholds)
- [x] New `input.size.limit.test.ts` covers: oversized path, oversized `Uint8Array`, oversized `Buffer`, non-regular-file rejection (`isFile() === false`), at-cap boundary, one-byte-over-cap
- [x] Path-separator tests in `path.traversal.test.ts`: POSIX `/`, Windows `\`, flat name passes, `pdfToPng` rejects `sub/page.png` end-to-end
- [x] `pdf.to.png.concurrency.limit.validation.test.ts`: at-cap pass, cap+1 throws, `Number.MAX_SAFE_INTEGER` throws, sequential mode ignores the cap

## Compatibility

- No breaking changes. New `maxInputBytes` is opt-out via large value, and the `concurrencyLimit` cap only rejects values above `16` — well above the documented default of `4`.
- The previously-flexible `outputFileMaskFunc` that returned nested filenames (e.g. `sub/page.png`) was **not** documented as supported and there is no existing test covering it; rejecting it is correct per the JSDoc which already implied flat filenames.