### PR TITLE
fix: require explicit CLI output mode

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.1.0"
   },
-  "sourceHash": "6633e0eee386f025cbaea12c3b62fa83ebf486892554f5fa6836c3f480065fa1",
+  "sourceHash": "50696f5b245f75d53229bb72eb45df02745a1fc84fdffeb4b9871fba15a56c54",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -61,103 +61,103 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
           "kind": "variable",
           "line": 14,
           "exported": true,
-          "signature": "export const HELP_TEXT = `Usage: pdf-to-png-converter <pdf-file-path> [options]\n\nOptions:\n  --output-folder <dir>             Folder path where PNG files will be written\n  --viewport-scale <number>   …"
+          "signature": "export const HELP_TEXT = `Usage: pdf-to-png-converter <pdf-file-path> [options]\n\nOptions:\n  --output-folder <dir>             Folder path where PNG files will be written (required unless --return-meta…"
         },
         {
           "name": "CLI_OPTIONS",
           "kind": "variable",
-          "line": 38,
+          "line": 37,
           "exported": false,
           "signature": "const CLI_OPTIONS = { 'output-folder': { type: 'string' }, 'viewport-scale': { type: 'string' }, 'use-system-fonts': { type: 'boolean' }, 'disable-font-face': { type: 'string' }, 'enable-xfa': { type:…"
         },
         {
           "name": "ParsedValues",
           "kind": "type",
-          "line": 56,
+          "line": 55,
           "exported": false,
           "signature": "type ParsedValues = { 'output-folder'?: string; 'viewport-scale'?: string; 'use-system-fonts'?: boolean; 'disable-font-face'?: string; 'enable-xfa'?: string; 'pdf-file-password'?: string; 'pages-to-pr…"
         },
         {
           "name": "CliParseResult",
           "kind": "type",
-          "line": 74,
+          "line": 73,
           "exported": false,
           "signature": "type CliParseResult = { values: ParsedValues; positionals: string[] };"
         },
         {
           "name": "parseBoolean",
           "kind": "function",
-          "line": 85,
+          "line": 84,
           "exported": true,
           "signature": "export function parseBoolean(val: string | undefined): boolean | undefined"
         },
         {
           "name": "parseNumberList",
           "kind": "function",
-          "line": 99,
+          "line": 98,
           "exported": true,
           "signature": "export function parseNumberList(val: string | undefined): number[] | undefined"
         },
         {
           "name": "parseNumericOption",
           "kind": "function",
-          "line": 110,
+          "line": 109,
           "exported": false,
           "signature": "function parseNumericOption(value: string | undefined, errorMessage: string): number | undefined"
         },
         {
           "name": "parseIntegerOption",
           "kind": "function",
-          "line": 123,
+          "line": 122,
           "exported": false,
           "signature": "function parseIntegerOption(value: string | undefined, errorMessage: string): number | undefined"
         },
         {
           "name": "safeParseArgs",
           "kind": "function",
-          "line": 136,
+          "line": 135,
           "exported": false,
           "signature": "function safeParseArgs(): CliParseResult | null"
         },
         {
           "name": "buildPdfToPngOptions",
           "kind": "function",
-          "line": 153,
+          "line": 156,
           "exported": true,
           "signature": "export function buildPdfToPngOptions( values: ParsedValues, positionals: string[], ): { pdfFilePath: string; options: NormalizedPdfToPngOptions }"
         },
         {
           "name": "executeConversion",
           "kind": "function",
-          "line": 183,
+          "line": 195,
           "exported": true,
-          "signature": "export async function executeConversion( pdfFilePath: string, options: NormalizedPdfToPngOptions, log: (...msgs: unknown[]) => void, ): Promise<void>"
+          "signature": "export async function executeConversion( pdfFilePath: string, options: NormalizedPdfToPngOptions, logInfo: (...msgs: unknown[]) => void, writeOutput: (...msgs: unknown[]) => void = console.log, ): Pro…"
         },
         {
           "name": "createLogger",
           "kind": "function",
-          "line": 204,
+          "line": 216,
           "exported": false,
           "signature": "function createLogger(silent: boolean | undefined): (...msgs: unknown[]) => void"
         },
         {
           "name": "handleRunError",
           "kind": "function",
-          "line": 210,
+          "line": 222,
           "exported": false,
           "signature": "function handleRunError(err: unknown): void"
         },
         {
           "name": "getVersion",
           "kind": "function",
-          "line": 229,
+          "line": 241,
           "exported": true,
           "signature": "export function getVersion(): string"
         },
         {
           "name": "run",
           "kind": "function",
-          "line": 249,
+          "line": 261,
           "exported": true,
           "signature": "export async function run(): Promise<void>"
         }

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npx pdf-to-png-converter my-document.pdf --output-folder ./output
 
 **Options:**
 
-- `--output-folder <dir>`: Directory to save PNG files. Existing files are not overwritten; duplicate output filenames throw `EEXIST`.
+- `--output-folder <dir>`: Directory to save PNG files. Required for image conversion. Existing files are not overwritten; duplicate output filenames throw `EEXIST`.
 - `--viewport-scale <number>`: Scale factor applied to each page viewport.
 - `--use-system-fonts`: Attempt to use fonts installed on the host system.
 - `--disable-font-face <true|false>`: Do not load embedded fonts.
@@ -115,13 +115,19 @@ npx pdf-to-png-converter my-document.pdf --output-folder ./output
 - `--pdf-file-password <pwd>`: Password for encrypted PDFs.
 - `--pages-to-process <n,m,...>`: Comma-separated list of 1-based page numbers.
 - `--verbosity-level <number>`: pdfjs verbosity level (0=errors, 1=warnings, 5=infos).
-- `--return-metadata-only`: Return page metadata without rendering images.
-- `--return-page-content`: Include rendered PNG buffers in the returned results. By default the CLI discards in-memory buffers after writing to disk (or when no output folder is set) to avoid unnecessary memory usage. Pass this flag to retain them.
+- `--return-metadata-only`: Return page metadata without rendering images. This prints JSON to stdout and does not require `--output-folder`.
 - `--process-pages-in-parallel`: Process pages concurrently.
 - `--concurrency-limit <number>`: Maximum number of pages rendered simultaneously.
 - `--silent`: Suppress normal output messages unless there is an error.
 - `--version`: Show package version.
 - `--help`: Show help text.
+
+The CLI has two output modes:
+
+- image conversion: writes PNG files to `--output-folder`
+- metadata inspection: prints JSON metadata to stdout with `--return-metadata-only`
+
+If you need in-memory PNG buffers, use the library API (`returnPageContent`) rather than the CLI.
 
 ---
 

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -114,6 +114,18 @@ describe('buildPdfToPngOptions', () => {
     it('throws when no pdf path is provided', () => {
         expect(() => buildPdfToPngOptions({}, [])).toThrow('<pdf-file-path> is required.');
     });
+
+    it('throws when image conversion is requested without --output-folder', () => {
+        expect(() => buildPdfToPngOptions({}, ['test.pdf'])).toThrow(
+            'The CLI requires --output-folder for image conversion. Use --return-metadata-only for stdout-friendly page metadata.',
+        );
+    });
+
+    it('throws when --return-page-content is used in the CLI', () => {
+        expect(() => buildPdfToPngOptions({ 'output-folder': '/out', 'return-page-content': true }, ['test.pdf'])).toThrow(
+            '--return-page-content is not supported by the CLI. Use the library API if you need in-memory PNG buffers.',
+        );
+    });
 });
 
 describe('executeConversion', () => {
@@ -123,6 +135,19 @@ describe('executeConversion', () => {
         await executeConversion('test.pdf', normalizePdfToPngOptions({ outputFolder: '/out' }), log);
 
         expect(log).toHaveBeenCalledWith('Successfully processed 0 page(s).');
+    });
+
+    it('writes metadata JSON without an informational banner', async () => {
+        vi.mocked(pdfToPngCore).mockResolvedValueOnce([
+            { kind: 'metadata', pageNumber: 1, name: 'page_1.png', width: 595, height: 842, rotation: 0, content: undefined, path: '' },
+        ]);
+        const logInfo = vi.fn();
+        const writeOutput = vi.fn();
+
+        await executeConversion('test.pdf', normalizePdfToPngOptions({ returnMetadataOnly: true }), logInfo, writeOutput);
+
+        expect(logInfo).not.toHaveBeenCalled();
+        expect(writeOutput).toHaveBeenCalledWith(expect.stringContaining('"pageNumber": 1'));
     });
 });
 
@@ -384,19 +409,24 @@ describe('CLI run()', () => {
         );
     });
 
-    it('passes --return-page-content flag through to pdfToPngCore', async () => {
+    it('rejects --return-page-content because the CLI has no observable buffer output mode', async () => {
         setArgv('test.pdf', '--output-folder', '/out', '--return-page-content');
         await run();
-        expect(pdfToPngCore).toHaveBeenCalledWith('test.pdf', expect.objectContaining({ returnPageContent: true }));
-        expect(exitSpy).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Error: --return-page-content is not supported by the CLI. Use the library API if you need in-memory PNG buffers.',
+        );
+        expect(pdfToPngCore).not.toHaveBeenCalled();
+        expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
-    it('calls pdfToPngCore without --output-folder (buffer / in-memory mode)', async () => {
+    it('rejects image conversion without --output-folder', async () => {
         setArgv('test.pdf');
         await run();
-        expect(pdfToPngCore).toHaveBeenCalledTimes(1);
-        expect(pdfToPngCore).toHaveBeenCalledWith('test.pdf', expect.objectContaining({ outputFolder: undefined }));
-        expect(exitSpy).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Error: The CLI requires --output-folder for image conversion. Use --return-metadata-only for stdout-friendly page metadata.',
+        );
+        expect(pdfToPngCore).not.toHaveBeenCalled();
+        expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
     it('does not log processing info in --silent mode', async () => {
@@ -421,16 +451,34 @@ describe('CLI run()', () => {
             'test.pdf',
             expect.objectContaining({ returnMetadataOnly: true, outputFolder: undefined }),
         );
-        expect(logSpy).toHaveBeenCalledWith('Metadata extraction complete:');
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('"pageNumber": 1'));
+        expect(logSpy).not.toHaveBeenCalledWith('Processing PDF: test.pdf');
+        expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('prints metadata JSON in --silent --return-metadata-only mode', async () => {
+        vi.mocked(pdfToPngCore).mockResolvedValueOnce([
+            { kind: 'metadata', pageNumber: 1, name: 'page_1.png', width: 595, height: 842, rotation: 0, content: undefined, path: '' },
+        ]);
+
+        setArgv('test.pdf', '--return-metadata-only', '--silent');
+        await run();
+        expect(pdfToPngCore).toHaveBeenCalledTimes(1);
         expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('"pageNumber": 1'));
         expect(exitSpy).not.toHaveBeenCalled();
     });
 
-    it('suppresses metadata output in --silent --return-metadata-only mode', async () => {
-        setArgv('test.pdf', '--return-metadata-only', '--silent');
+    it('does not log output-folder chatter in metadata-only mode because no files are written', async () => {
+        vi.mocked(pdfToPngCore).mockResolvedValueOnce([
+            { kind: 'metadata', pageNumber: 1, name: 'page_1.png', width: 595, height: 842, rotation: 0, content: undefined, path: '' },
+        ]);
+
+        setArgv('test.pdf', '--return-metadata-only', '--output-folder', '/out');
         await run();
-        expect(pdfToPngCore).toHaveBeenCalledTimes(1);
-        expect(logSpy).not.toHaveBeenCalled();
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('"pageNumber": 1'));
+        expect(logSpy).not.toHaveBeenCalledWith('Processing PDF: test.pdf');
+        expect(logSpy).not.toHaveBeenCalledWith('Output folder: /out');
         expect(exitSpy).not.toHaveBeenCalled();
     });
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 `pdf-to-png-converter` is a CJS-only Node.js library and CLI for converting PDF pages into PNG images or page metadata.
 
-The codebase is organized around one public library entrypoint (`pdfToPng`) plus a thin CLI adapter. The library normalizes options first, loads the PDF through `pdfjs-dist`, processes pages sequentially or through a sliding-window scheduler, and routes rendered PNG buffers either to disk or an in-memory/null sink.
+The codebase is organized around one public library entrypoint (`pdfToPng`) plus a thin CLI adapter. The library normalizes options first, loads the PDF through `pdfjs-dist`, processes pages sequentially or through a sliding-window scheduler, and routes rendered PNG buffers either to disk or an in-memory/null sink. The CLI is intentionally narrower than the API: it either writes image files to `--output-folder` or prints metadata JSON to stdout with `--return-metadata-only`.
 
 ## Public surfaces
 
@@ -99,7 +99,9 @@ Residual risk remains for directory-component swaps between checks; the library 
 
 1. `safeParseArgs()` parses argv.
 2. `buildPdfToPngOptions()` converts CLI values into a normalized `PdfToPngOptions` object.
-3. `executeConversion()` delegates to `pdfToPng()`.
+3. `buildPdfToPngOptions()` rejects CLI-only dead-end modes before any PDF work starts:
+    - image conversion without `--output-folder`
+    - `--return-page-content` (library API only)
 4. `run()` handles process exit codes and output formatting.
 5. `getVersion()` treats missing/malformed `package.json` as a packaging defect and exits with an error.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ import { normalizePdfToPngOptions, type NormalizedPdfToPngOptions } from './norm
 export const HELP_TEXT = `Usage: pdf-to-png-converter <pdf-file-path> [options]
 
 Options:
-  --output-folder <dir>             Folder path where PNG files will be written
+  --output-folder <dir>             Folder path where PNG files will be written (required unless --return-metadata-only)
   --viewport-scale <number>         Scale factor applied to each page viewport
   --use-system-fonts                Attempt to use fonts installed on the host system
   --disable-font-face <true|false>  Do not load embedded fonts (true/false)
@@ -23,7 +23,6 @@ Options:
   --pages-to-process <n,m,...>      Comma-separated list of 1-based page numbers
   --verbosity-level <number>        pdfjs verbosity level (0=errors, 1=warnings, 5=infos)
   --return-metadata-only            Return page metadata without rendering images
-  --return-page-content             Retain rendered PNG buffers in results (default: false)
   --process-pages-in-parallel       Process pages concurrently
   --concurrency-limit <number>      Maximum number of pages rendered simultaneously
   --silent                          Suppress output unless there is an error
@@ -149,6 +148,10 @@ function safeParseArgs(): CliParseResult | null {
  * Parses raw CLI flags into a validated `NormalizedPdfToPngOptions` plus the positional
  * `pdfFilePath`. Single source of normalization — downstream {@link executeConversion}
  * passes the result straight to {@link pdfToPngCore} so the library does NOT re-normalize.
+ *
+ * The CLI only supports stdout-friendly metadata mode (`--return-metadata-only`) or
+ * file-writing image conversion (`--output-folder`). In-memory PNG buffers remain a
+ * library-only capability because the CLI does not serialize page results.
  */
 export function buildPdfToPngOptions(
     values: ParsedValues,
@@ -174,26 +177,35 @@ export function buildPdfToPngOptions(
         concurrencyLimit: parseIntegerOption(values['concurrency-limit'], '--concurrency-limit must be a valid integer.'),
     };
 
-    return {
-        pdfFilePath,
-        options: normalizePdfToPngOptions(rawOptions),
-    };
+    const options = normalizePdfToPngOptions(rawOptions);
+
+    if (values['return-page-content']) {
+        throw new Error('--return-page-content is not supported by the CLI. Use the library API if you need in-memory PNG buffers.');
+    }
+
+    if (!options.returnMetadataOnly && options.outputFolder === undefined) {
+        throw new Error(
+            'The CLI requires --output-folder for image conversion. Use --return-metadata-only for stdout-friendly page metadata.',
+        );
+    }
+
+    return { pdfFilePath, options };
 }
 
 export async function executeConversion(
     pdfFilePath: string,
     options: NormalizedPdfToPngOptions,
-    log: (...msgs: unknown[]) => void,
+    logInfo: (...msgs: unknown[]) => void,
+    writeOutput: (...msgs: unknown[]) => void = console.log,
 ): Promise<void> {
     try {
         const results = await pdfToPngCore(pdfFilePath, options);
         if (options.returnMetadataOnly) {
-            log('Metadata extraction complete:');
-            log(JSON.stringify(results, null, 2));
+            writeOutput(JSON.stringify(results, null, 2));
             return;
         }
 
-        log(`Successfully processed ${results.length} page(s).`);
+        logInfo(`Successfully processed ${results.length} page(s).`);
     } catch (err: unknown) {
         throw new Error(err instanceof Error ? err.message : String(err), {
             cause: err,
@@ -271,12 +283,14 @@ export async function run(): Promise<void> {
 
     try {
         const { pdfFilePath, options } = buildPdfToPngOptions(values, positionals);
-        const log = createLogger(values.silent);
-        log(`Processing PDF: ${pdfFilePath}`);
-        if (options.outputFolder) {
-            log(`Output folder: ${options.outputFolder}`);
+        const logInfo = createLogger(values.silent);
+        if (!options.returnMetadataOnly) {
+            logInfo(`Processing PDF: ${pdfFilePath}`);
+            if (options.outputFolder) {
+                logInfo(`Output folder: ${options.outputFolder}`);
+            }
         }
-        await executeConversion(pdfFilePath, options, log);
+        await executeConversion(pdfFilePath, options, logInfo);
     } catch (err: unknown) {
         handleRunError(err);
     }


### PR DESCRIPTION
## Summary
- require `--output-folder` for CLI image conversion instead of succeeding with no observable output
- keep metadata mode as a clean JSON-on-stdout path and reject `--return-page-content` in the CLI
- add CLI regression tests and align README, architecture docs, and CODEMAP

## Verification
- `npx vitest run __tests__/cli.test.ts __tests__/cli.single.normalize.test.ts`
- `npm run build:test`
- `npm run build:strict`
- `npm run lint`
- `npm run codemap`
- `npm run codemap:check`
- `./node_modules/.bin/prettier --check src/cli.ts __tests__/cli.test.ts README.md docs/ARCHITECTURE.md CODEMAP.md`
- `git diff --check`

## Review
- reviewer subagent re-reviewed the updated diff and reported no remaining findings