### PR TITLE
Fix empty numeric CLI flags being accepted as zero

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.1.0"
   },
-  "sourceHash": "73fa04f1b7509178a35851d11eab6cac5a607b1e071d2a5721e59f35ebe40b0d",
+  "sourceHash": "716f4ac8f9cdf9f3974283c4d408b51a07d76fe52ea320288633891e64453749",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -108,56 +108,56 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "parseIntegerOption",
           "kind": "function",
-          "line": 122,
+          "line": 125,
           "exported": false,
           "signature": "function parseIntegerOption(value: string | undefined, errorMessage: string): number | undefined"
         },
         {
           "name": "safeParseArgs",
           "kind": "function",
-          "line": 135,
+          "line": 141,
           "exported": false,
           "signature": "function safeParseArgs(): CliParseResult | null"
         },
         {
           "name": "buildPdfToPngOptions",
           "kind": "function",
-          "line": 156,
+          "line": 162,
           "exported": true,
           "signature": "export function buildPdfToPngOptions( values: ParsedValues, positionals: string[], ): { pdfFilePath: string; options: NormalizedPdfToPngOptions }"
         },
         {
           "name": "executeConversion",
           "kind": "function",
-          "line": 195,
+          "line": 201,
           "exported": true,
           "signature": "export async function executeConversion( pdfFilePath: string, options: NormalizedPdfToPngOptions, logInfo: (...msgs: unknown[]) => void, writeOutput: (...msgs: unknown[]) => void = console.log, ): Pro…"
         },
         {
           "name": "createLogger",
           "kind": "function",
-          "line": 216,
+          "line": 222,
           "exported": false,
           "signature": "function createLogger(silent: boolean | undefined): (...msgs: unknown[]) => void"
         },
         {
           "name": "handleRunError",
           "kind": "function",
-          "line": 222,
+          "line": 228,
           "exported": false,
           "signature": "function handleRunError(err: unknown): void"
         },
         {
           "name": "getVersion",
           "kind": "function",
-          "line": 241,
+          "line": 247,
           "exported": true,
           "signature": "export function getVersion(): string"
         },
         {
           "name": "run",
           "kind": "function",
-          "line": 261,
+          "line": 267,
           "exported": true,
           "signature": "export async function run(): Promise<void>"
         }

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -126,6 +126,18 @@ describe('buildPdfToPngOptions', () => {
             '--return-page-content is not supported by the CLI. Use the library API if you need in-memory PNG buffers.',
         );
     });
+
+    it('throws when --verbosity-level is provided as an empty string', () => {
+        expect(() => buildPdfToPngOptions({ 'verbosity-level': '', 'return-metadata-only': true }, ['test.pdf'])).toThrow(
+            '--verbosity-level must be a valid integer.',
+        );
+    });
+
+    it('throws when --viewport-scale is provided as an empty string', () => {
+        expect(() => buildPdfToPngOptions({ 'viewport-scale': '', 'return-metadata-only': true }, ['test.pdf'])).toThrow(
+            '--viewport-scale must be a valid number.',
+        );
+    });
 });
 
 describe('executeConversion', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -110,6 +110,9 @@ function parseNumericOption(value: string | undefined, errorMessage: string): nu
     if (value === undefined) {
         return undefined;
     }
+    if (value.trim() === '') {
+        throw new Error(errorMessage);
+    }
 
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) {
@@ -122,6 +125,9 @@ function parseNumericOption(value: string | undefined, errorMessage: string): nu
 function parseIntegerOption(value: string | undefined, errorMessage: string): number | undefined {
     if (value === undefined) {
         return undefined;
+    }
+    if (value.trim() === '') {
+        throw new Error(errorMessage);
     }
 
     const parsed = Number(value);


### PR DESCRIPTION
## Summary

- Fixed empty numeric CLI flag values being coerced to 0 instead of being rejected
- Added regression coverage for blank --verbosity-level and --viewport-scale inputs

## Root Cause

buildPdfToPngOptions() in src/cli.ts parses CLI numeric strings through parseNumericOption() and parseIntegerOption(). Both helpers called Number(value) without first rejecting blank strings, so an explicit empty value such as --verbosity-level= was coerced to 0 by JavaScript. That let the CLI silently accept an invalid integer for verbosityLevel, and it turned --viewport-scale= into a misleading downstream validation error about 0 rather than a direct CLI parse failure.

## Fix

Added a shared value.trim() ===  guard in parseNumericOption() and parseIntegerOption() so blank numeric arguments now fail immediately with the existing CLI-specific error messages. This is the minimal correct fix because it leaves the rest of the normalization and validation pipeline unchanged.

## Tests

- ./node_modules/.bin/vitest run __tests__/cli.test.ts => 50 passed
- npm run build:test => passed
- npm run build:strict => passed
- ./node_modules/.bin/vitest run __tests__/pdf.as.buffer.to.file.test.ts => passed
- ./node_modules/.bin/vitest run __tests__/pdf.to.file.sample.test.ts => passed
- npm test => pretest passed, then the full suite hit an unrelated existing failure: __tests__/pdf.as.buffer.to.file.test.ts and __tests__/pdf.to.file.sample.test.ts both use test-results/sample/actual, so parallel execution can produce ENOENT in src/outputWriter.ts when one test removes the shared directory while the other is writing.

## Risk

Low. The change is isolated to CLI-only numeric parsing in src/cli.ts; library behavior and output generation are untouched.
