### PR TITLE
fix: reject duplicate output filenames before any write (VAL-001)

### DIFF
--- a/BACKLOG-ARCHIVE.md
+++ b/BACKLOG-ARCHIVE.md
@@ -82,3 +82,6 @@
 - [x] 🟡 🐛 SEC-003 Sec: cap concurrencyLimit upper bound
     - **Impl:** MAX_CONCURRENCY_LIMIT=16 enforced in normalizePdfToPngOptions when processPagesInParallel
     - **Rat:** N workers × 400MB canvas cap = attacker-driven memory blowup; default 4 unaffected
+- [x] 🔴 🐛 VAL-001 Core: output filename collisions abort conversion with cryptic EEXIST + partial writes
+    - **Impl:** resolve all page names up front in pdfToPngCore; findDuplicateOutputName pre-flight check throws a clear plain Error (flat filename + conflicting pages, no absolute path) before any output I/O when outputFolder is set; resolved names threaded by index into sequential + sliding-window loops
+    - **Rat:** non-injective outputFileMaskFunc / duplicate pagesToProcess hit exclusive-create 'wx' mid-run → raw EEXIST, nondeterministic in parallel, leaked absolute path, and left the first colliding file on disk; pre-flight check makes it fail-fast and atomic. Gated on disk-writes only — in-memory/metadata conversions may legitimately repeat names

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.1.0"
   },
-  "sourceHash": "a9d1866fd2dd1a1e5a4f77b3c9c8208145a085d8a04f38140bfbdf751e90f645",
+  "sourceHash": "51155f3baa94c5b7019cc3ed1b1b983f46e9ec50cd151c2becc9fd24a83ccfe9",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -874,7 +874,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "pdfToPngCore",
           "kind": "function",
-          "line": 84,
+          "line": 80,
           "exported": true,
           "signature": "export async function pdfToPngCore( pdfFile: string | ArrayBufferLike | Uint8Array, normalizedProps: NormalizedPdfToPngOptions, ): Promise<PngPageOutput[]>"
         }

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.1.0"
   },
-  "sourceHash": "716f4ac8f9cdf9f3974283c4d408b51a07d76fe52ea320288633891e64453749",
+  "sourceHash": "a9d1866fd2dd1a1e5a4f77b3c9c8208145a085d8a04f38140bfbdf751e90f645",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -862,12 +862,19 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
           "kind": "function",
           "line": 14,
           "exported": false,
-          "signature": "async function processPagesWithSlidingWindow<T>( pageNumbers: number[], concurrencyLimit: number, processPage: (pageNumber: number) => Promise<T>, ): Promise<T[]>"
+          "signature": "async function processPagesWithSlidingWindow<T>( pageNumbers: number[], concurrencyLimit: number, processPage: (pageNumber: number, index: number) => Promise<T>, ): Promise<T[]>"
+        },
+        {
+          "name": "findDuplicateOutputName",
+          "kind": "function",
+          "line": 56,
+          "exported": false,
+          "signature": "function findDuplicateOutputName(names: string[], pageNumbers: number[]): { name: string; pages: number[] } | undefined"
         },
         {
           "name": "pdfToPngCore",
           "kind": "function",
-          "line": 55,
+          "line": 84,
           "exported": true,
           "signature": "export async function pdfToPngCore( pdfFile: string | ArrayBufferLike | Uint8Array, normalizedProps: NormalizedPdfToPngOptions, ): Promise<PngPageOutput[]>"
         }

--- a/__tests__/pdf.to.png.duplicate.filename.test.ts
+++ b/__tests__/pdf.to.png.duplicate.filename.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeEach, describe, expect, test } from 'vitest';
 import { pdfToPng } from '../src/pdfToPng';
 
 const pdfFilePath: string = resolve('./test-data/sample.pdf');
+const multiPagePdfFilePath: string = resolve('./test-data/large_pdf.pdf');
 const baseOutputFolder: string = resolve('./test-results/duplicate-filename');
 
 async function pngFilesIn(folder: string): Promise<string[]> {
@@ -105,5 +106,22 @@ describe('VAL-001: duplicate output filename pre-flight check', () => {
         expect(pages).toHaveLength(2);
         expect(pages.every((page) => page.name === 'same.png')).toBe(true);
         expect(pages.every((page) => page.path === '')).toBe(true);
+    });
+
+    test('(g) non-adjacent colliding pages are reported with the correct page list', async () => {
+        const outputFolder = join(baseOutputFolder, 'non-adjacent');
+        await fsPromises.mkdir(outputFolder, { recursive: true });
+
+        // Pages 1 and 3 collide on "collide.png"; page 2 is distinct. The reported page list
+        // must list the non-adjacent colliding pages (1, 3), not the distinct page 2.
+        await expect(
+            pdfToPng(multiPagePdfFilePath, {
+                outputFolder,
+                outputFileMaskFunc: (pageNumber: number) => (pageNumber === 2 ? 'unique_2.png' : 'collide.png'),
+                pagesToProcess: [1, 2, 3],
+            }),
+        ).rejects.toThrow(/Duplicate output filename "collide\.png" for pages 1, 3\./);
+
+        expect(await pngFilesIn(outputFolder)).toHaveLength(0);
     });
 });

--- a/__tests__/pdf.to.png.duplicate.filename.test.ts
+++ b/__tests__/pdf.to.png.duplicate.filename.test.ts
@@ -1,0 +1,109 @@
+import { promises as fsPromises } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeEach, describe, expect, test } from 'vitest';
+import { pdfToPng } from '../src/pdfToPng';
+
+const pdfFilePath: string = resolve('./test-data/sample.pdf');
+const baseOutputFolder: string = resolve('./test-results/duplicate-filename');
+
+async function pngFilesIn(folder: string): Promise<string[]> {
+    try {
+        const entries = await fsPromises.readdir(folder);
+        return entries.filter((entry) => entry.endsWith('.png'));
+    } catch {
+        return [];
+    }
+}
+
+beforeEach(async () => {
+    await fsPromises.rm(baseOutputFolder, { recursive: true, force: true });
+});
+
+afterAll(async () => {
+    await fsPromises.rm(baseOutputFolder, { recursive: true, force: true });
+});
+
+describe('VAL-001: duplicate output filename pre-flight check', () => {
+    test('(a) duplicate pagesToProcess + outputFolder throws a clear error and writes no files', async () => {
+        const outputFolder = join(baseOutputFolder, 'dup-pages');
+        // Pre-create the folder so the assertion proves we did not write despite it existing.
+        await fsPromises.mkdir(outputFolder, { recursive: true });
+
+        await expect(pdfToPng(pdfFilePath, { outputFolder, pagesToProcess: [1, 1] })).rejects.toThrow(
+            /Duplicate output filename "sample_page_1\.png" for pages 1, 1\./,
+        );
+
+        expect(await pngFilesIn(outputFolder)).toHaveLength(0);
+    });
+
+    test('(b) non-injective outputFileMaskFunc over multiple pages throws and writes no files', async () => {
+        const outputFolder = join(baseOutputFolder, 'non-injective');
+        await fsPromises.mkdir(outputFolder, { recursive: true });
+
+        await expect(
+            pdfToPng(pdfFilePath, {
+                outputFolder,
+                outputFileMaskFunc: () => 'same.png',
+                pagesToProcess: [1, 2],
+            }),
+        ).rejects.toThrow(/Duplicate output filename "same\.png" for pages 1, 2\./);
+
+        expect(await pngFilesIn(outputFolder)).toHaveLength(0);
+    });
+
+    test('(c) regression: injective custom mask with dup-free pages still succeeds', async () => {
+        const outputFolder = join(baseOutputFolder, 'injective-ok');
+
+        const pages = await pdfToPng(pdfFilePath, {
+            outputFolder,
+            outputFileMaskFunc: (pageNumber: number) => `custom_${pageNumber}.png`,
+            pagesToProcess: [1, 2],
+        });
+
+        expect(pages).toHaveLength(2);
+        expect(pages.map((page) => page.name)).toEqual(['custom_1.png', 'custom_2.png']);
+        expect(await pngFilesIn(outputFolder)).toHaveLength(2);
+    });
+
+    test('(d) parallel mode raises the same deterministic error', async () => {
+        const outputFolder = join(baseOutputFolder, 'parallel');
+        await fsPromises.mkdir(outputFolder, { recursive: true });
+
+        await expect(
+            pdfToPng(pdfFilePath, {
+                outputFolder,
+                outputFileMaskFunc: () => 'same.png',
+                pagesToProcess: [1, 2],
+                processPagesInParallel: true,
+            }),
+        ).rejects.toThrow(/Duplicate output filename "same\.png" for pages 1, 2\./);
+
+        expect(await pngFilesIn(outputFolder)).toHaveLength(0);
+    });
+
+    test('(e) error message does not leak the absolute output path', async () => {
+        const outputFolder = join(baseOutputFolder, 'no-path-leak');
+
+        let message = '';
+        try {
+            await pdfToPng(pdfFilePath, { outputFolder, pagesToProcess: [1, 1] });
+        } catch (error: unknown) {
+            message = error instanceof Error ? error.message : String(error);
+        }
+
+        expect(message).toMatch(/Duplicate output filename/);
+        expect(message).not.toContain(outputFolder);
+        expect(message).not.toContain(process.cwd());
+    });
+
+    test('(f) gating: duplicate names with no outputFolder (in-memory) do not throw', async () => {
+        const pages = await pdfToPng(pdfFilePath, {
+            outputFileMaskFunc: () => 'same.png',
+            pagesToProcess: [1, 2],
+        });
+
+        expect(pages).toHaveLength(2);
+        expect(pages.every((page) => page.name === 'same.png')).toBe(true);
+        expect(pages.every((page) => page.path === '')).toBe(true);
+    });
+});

--- a/src/pdfToPngCore.ts
+++ b/src/pdfToPngCore.ts
@@ -14,7 +14,7 @@ import { getPdfDocument } from './pdfjsLoader.js';
 async function processPagesWithSlidingWindow<T>(
     pageNumbers: number[],
     concurrencyLimit: number,
-    processPage: (pageNumber: number) => Promise<T>,
+    processPage: (pageNumber: number, index: number) => Promise<T>,
 ): Promise<T[]> {
     const results = new Array<T>(pageNumbers.length);
     let nextIndex = 0;
@@ -25,7 +25,7 @@ async function processPagesWithSlidingWindow<T>(
             const currentIndex = nextIndex;
             nextIndex += 1;
             try {
-                results[currentIndex] = await processPage(pageNumbers[currentIndex]);
+                results[currentIndex] = await processPage(pageNumbers[currentIndex], currentIndex);
             } catch (error: unknown) {
                 firstError ??= error;
             }
@@ -40,6 +40,35 @@ async function processPagesWithSlidingWindow<T>(
     }
 
     return results;
+}
+
+/**
+ * Finds the first output filename that more than one processed page resolves to.
+ *
+ * Page names are resolved up front (before any output I/O) so a non-injective `outputFileMaskFunc`
+ * or a duplicated `pagesToProcess` entry surfaces as a clear, deterministic error instead of a raw
+ * `EEXIST` from the exclusive-create (`'wx'`) write — which previously also left the first colliding
+ * file on disk and leaked the absolute output path. See VAL-001.
+ *
+ * Iterates in first-seen order, so the reported duplicate is deterministic regardless of whether
+ * pages are later rendered sequentially or in parallel.
+ */
+function findDuplicateOutputName(names: string[], pageNumbers: number[]): { name: string; pages: number[] } | undefined {
+    const pagesByName = new Map<string, number[]>();
+    for (let index = 0; index < names.length; index += 1) {
+        const existing = pagesByName.get(names[index]);
+        if (existing === undefined) {
+            pagesByName.set(names[index], [pageNumbers[index]]);
+        } else {
+            existing.push(pageNumbers[index]);
+        }
+    }
+    for (const [name, pages] of pagesByName) {
+        if (pages.length > 1) {
+            return { name, pages };
+        }
+    }
+    return undefined;
 }
 
 /**
@@ -69,6 +98,28 @@ export async function pdfToPngCore(
         const returnMetadataOnly = normalizedProps.returnMetadataOnly;
         const resolvedOutputFolder: string | undefined =
             normalizedProps.outputFolder !== undefined && !returnMetadataOnly ? resolve(normalizedProps.outputFolder) : undefined;
+
+        const defaultMask: string = typeof pdfFile === 'string' ? parse(pdfFile).name : PDF_TO_PNG_OPTIONS_DEFAULTS.outputFileMask;
+
+        // Resolve every page name up front. resolvePageName also enforces the non-empty and
+        // flat-filename rules, so that validation continues to fire for in-memory conversions too.
+        const resolvedNames: string[] = validPagesToProcess.map((pageNumber) =>
+            resolvePageName(pageNumber, defaultMask, normalizedProps.outputFileMaskFunc),
+        );
+
+        // Collisions only corrupt output when pages are written to disk; in-memory / metadata-only
+        // conversions may legitimately repeat a name. Reject duplicates before any output I/O
+        // (before mkdir/realpath/write) so nothing is created and no partial output is left behind.
+        if (resolvedOutputFolder !== undefined) {
+            const duplicate = findDuplicateOutputName(resolvedNames, validPagesToProcess);
+            if (duplicate !== undefined) {
+                throw new Error(
+                    `Duplicate output filename "${duplicate.name}" for pages ${duplicate.pages.join(', ')}. ` +
+                        `Each processed page must resolve to a unique filename.`,
+                );
+            }
+        }
+
         if (resolvedOutputFolder !== undefined) {
             await fsPromises.mkdir(resolvedOutputFolder, { recursive: true });
         }
@@ -76,7 +127,6 @@ export async function pdfToPngCore(
             resolvedOutputFolder !== undefined ? await fsPromises.realpath(resolvedOutputFolder) : undefined;
         const pngPageOutputs: PngPageOutput[] = [];
 
-        const defaultMask: string = typeof pdfFile === 'string' ? parse(pdfFile).name : PDF_TO_PNG_OPTIONS_DEFAULTS.outputFileMask;
         const shouldReturnContent: boolean = returnMetadataOnly
             ? false
             : normalizedProps.outputFolder
@@ -88,10 +138,10 @@ export async function pdfToPngCore(
                 : shouldReturnContent
                   ? new NullSink()
                   : undefined;
-        const processPage = async (pageNumber: number): Promise<PngPageOutput> =>
+        const processPage = async (pageNumber: number, index: number): Promise<PngPageOutput> =>
             await processAndSavePage(
                 pdfDocument,
-                resolvePageName(pageNumber, defaultMask, normalizedProps.outputFileMaskFunc),
+                resolvedNames[index],
                 pageNumber,
                 pageViewportScale,
                 shouldReturnContent,
@@ -105,8 +155,8 @@ export async function pdfToPngCore(
                 ...(await processPagesWithSlidingWindow(validPagesToProcess, normalizedProps.concurrencyLimit, processPage)),
             );
         } else {
-            for (const pageNumber of validPagesToProcess) {
-                pngPageOutputs.push(await processPage(pageNumber));
+            for (const [index, pageNumber] of validPagesToProcess.entries()) {
+                pngPageOutputs.push(await processPage(pageNumber, index));
             }
         }
 

--- a/src/pdfToPngCore.ts
+++ b/src/pdfToPngCore.ts
@@ -56,12 +56,8 @@ async function processPagesWithSlidingWindow<T>(
 function findDuplicateOutputName(names: string[], pageNumbers: number[]): { name: string; pages: number[] } | undefined {
     const pagesByName = new Map<string, number[]>();
     for (let index = 0; index < names.length; index += 1) {
-        const existing = pagesByName.get(names[index]);
-        if (existing === undefined) {
-            pagesByName.set(names[index], [pageNumbers[index]]);
-        } else {
-            existing.push(pageNumbers[index]);
-        }
+        const existing = pagesByName.get(names[index]) ?? [];
+        pagesByName.set(names[index], [...existing, pageNumbers[index]]);
     }
     for (const [name, pages] of pagesByName) {
         if (pages.length > 1) {
@@ -118,9 +114,6 @@ export async function pdfToPngCore(
                         `Each processed page must resolve to a unique filename.`,
                 );
             }
-        }
-
-        if (resolvedOutputFolder !== undefined) {
             await fsPromises.mkdir(resolvedOutputFolder, { recursive: true });
         }
         const realOutputFolder: string | undefined =


### PR DESCRIPTION
## Summary

Fixes **VAL-001** (🔴 bug). A non-injective `outputFileMaskFunc` or a duplicated `pagesToProcess` entry made two pages resolve to the same output filename. Because writes use exclusive-create (`'wx'`, from SEC-001's TOCTOU hardening), the second `open()` failed mid-conversion with a raw `EEXIST` that:

- leaked the **absolute output path** in the error,
- was **nondeterministic** in parallel mode (which page failed depended on scheduling),
- left the **first colliding file on disk** (non-atomic failure).

### Fix

`pdfToPngCore` now resolves every page name **up front** and runs a pre-flight uniqueness check (`findDuplicateOutputName`) that throws a clear, deterministic plain `Error` naming the **flat** duplicate filename + conflicting page numbers — **before any output I/O** (before `mkdir`/`realpath`/`write`). Exclusive-create `'wx'` is kept. Resolved names are threaded by **index** into both the sequential and sliding-window loops so duplicated `pagesToProcess` (e.g. `[1,1]`) map unambiguously.

Example error: `Duplicate output filename "same.png" for pages 1, 2. Each processed page must resolve to a unique filename.`

### Design decisions (grilled & approved)

- **Gated on disk-writes only** (`outputFolder` set, not metadata-only). In-memory / metadata-only conversions may legitimately repeat names and are untouched.
- **Plain `Error`**, not a new custom error class — matches the repo's error convention; no new public surface.
- Per-page empty/separator validation in `resolvePageName` still fires for **every** conversion (in-memory included) — preserved by resolving up front.

## Architecture decisions

- No public API signature change. `pdfToPng()` / `pdfToPngCore()` signatures unchanged.
- Behavioral change only: a previously-`EEXIST` path now throws a clearer message **earlier**, before any file is created.
- Internal helper `findDuplicateOutputName` is module-private (not exported from `index.ts`).

## Testing

New suite `__tests__/pdf.to.png.duplicate.filename.test.ts` (6 tests):

- (a) duplicate `pagesToProcess: [1,1]` + `outputFolder` → clear error, **no files written** (asserted against a pre-created folder).
- (b) non-injective `outputFileMaskFunc` over 2 pages → same; no files written.
- (c) **regression:** injective custom mask + dup-free pages → succeeds, 2 files written.
- (d) `processPagesInParallel: true` → same **deterministic** error.
- (e) error message does **not** contain the absolute output path / `cwd`.
- (f) **gating regression:** duplicate names with **no** `outputFolder` (in-memory) → does **not** throw.

Full suite: **207 passed / 2 pre-existing skips (38 files)**. Coverage **97.53% stmts / 94.18% branches** (≥80%). Strict build, codemap check, format, lint all green.

## CLI / Skill / Docs

- **CLI:** no change needed — `cli.ts` calls `pdfToPngCore` directly and inherits the new error automatically. No new flags.
- **Skill:** N/A — this is a published library, not a skill host.
- **Docs:** `CODEMAP.md` regenerated via `npm run codemap`. README unchanged (the error contract isn't documented there). `BACKLOG.md` → `BACKLOG-ARCHIVE.md` moved per repo agent rules.

## Risk & rollback

- **Risk:** behavioral/error-contract change — a caller catching the raw `EEXIST` would now see a different (clearer) message. Low: the old behavior was an unhandled internal errno, not a documented contract.
- **Rollback:** revert this single commit/PR. No schema/auth/persistence/dependency impact.

## Known limitations

- The check is intentionally scoped to disk-writes; duplicate `name` values in returned in-memory results remain the caller's responsibility (by design).

## Backlog

- **Linked:** VAL-001.
- **Intentionally excluded:** ARCH-009/010/012/014/016 (deferred per approved scope; remain in `BACKLOG.md`).

## Checklist

- [x] Backlog item(s) linked
- [x] Excluded backlog items listed
- [x] Feature implemented
- [x] Unit tests added or updated
- [ ] Integration tests added or updated, if applicable — N/A (covered via public-API tests)
- [x] Regression tests added (c, f)
- [ ] CLI updated — N/A (inherits behavior; no new flags)
- [ ] CLI tests updated — N/A
- [ ] Skill updated — N/A (library, no skills)
- [x] Documentation updated (CODEMAP, backlog archive)
- [ ] API docs updated — N/A (no API change)
- [x] Codemap regenerated
- [x] ESLint passes
- [x] TypeScript passes (incl. strict)
- [x] Relevant tests pass
- [ ] CI passes — pending CI run
- [ ] Reviewer findings addressed — pending independent review
- [ ] Copilot findings addressed, if available — pending
- [x] Branch rebased onto latest main (branched from current main)
- [x] Rollback strategy documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)