### PR TITLE
chore: drop out/.tsbuildinfo from published tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The published npm tarball no longer ships `out/.tsbuildinfo`. `incremental` is disabled in `tsconfig.prod.json` (and the unused `tsBuildInfoFile` setting removed) — the `prebuild` step runs `clean`, which wipes `out/` before every build, so incremental compilation never had any effect here. Removing the file drops the tarball from 48 to 47 files (~45 kB → ~30 kB packed). No runtime, type, or API change.
+
 ## [4.1.0] — 2026-06-02
 
 ### Removed

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -5,8 +5,7 @@
         "outDir": "./out",
         "noEmit": false,
         "declaration": true,
-        "incremental": true,
-        "tsBuildInfoFile": "./out/.tsbuildinfo"
+        "incremental": false
     },
     "include": ["./src/**/*"]
 }


### PR DESCRIPTION
## Summary
Stops `out/.tsbuildinfo` from shipping in the npm package.

`tsconfig.prod.json` had `incremental: true` + `tsBuildInfoFile: ./out/.tsbuildinfo`, but `prebuild` runs `clean` (wipes `out/`) before every build — so incremental compilation never actually took effect. Its only observable result was a ~53 kB `.tsbuildinfo` file leaking into the tarball (present since before 4.0.0).

This disables `incremental` and removes the now-unused `tsBuildInfoFile`.

## Effect on the tarball
| | Before | After |
|---|---|---|
| files | 48 | 47 |
| packed | 45.4 kB | 30.0 kB |
| unpacked | 149.3 kB | 96.4 kB |

No runtime, type, or public-API change. Verified locally: `npm run build` no longer emits `out/.tsbuildinfo`; `npm pack --dry-run` confirms its absence.

## Verification (local)
- ✅ `build` (prod) emits cleanly, no `.tsbuildinfo`
- ✅ `build:strict`, `codemap:check`, `format:check`, `lint`

## Test plan
- [ ] CI (`test.yml`) green
- [ ] Merge to `main` (lands under CHANGELOG `[Unreleased]` for the next release)