### PR TITLE
Fix duplicate output filename collisions on case-insensitive filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The duplicate-output-filename pre-flight check (VAL-001) now detects collisions **case-insensitively**. Previously it compared resolved page filenames with exact string equality, so two names differing only in case (e.g. an `outputFileMaskFunc` returning `Page.png` for one page and `page.png` for another) passed the check. On case-insensitive, case-preserving filesystems — the default on macOS (APFS) and Windows (NTFS) — those names are the **same file**, so the second exclusive-create (`'wx'`) write failed with a raw `EEXIST` that left the first file on disk and **leaked the absolute output path** in the error message — exactly the partial-output + path-leak failure mode VAL-001 was introduced to prevent. The pre-flight now lower-cases names when keying, so the clean `Duplicate output filename "…" for pages …` error is thrown before any I/O on every platform; the reported name preserves the first-seen original casing. In-memory / metadata-only conversions (no `outputFolder`) still allow repeated names. This makes the "each processed page must resolve to a unique filename" guarantee hold portably regardless of the host filesystem.
+
 ### Changed
 
 - The published npm tarball no longer ships `out/.tsbuildinfo`. `incremental` is disabled in `tsconfig.prod.json` (and the unused `tsBuildInfoFile` setting removed) — the `prebuild` step runs `clean`, which wipes `out/` before every build, so incremental compilation never had any effect here. Removing the file drops the tarball from 48 to 47 files (~45 kB → ~30 kB packed). No runtime, type, or API change.

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.1.0"
   },
-  "sourceHash": "a64d89b73f09c871f556ab107ed2838684a62d4a27f93f2693d41c13c8cf6574",
+  "sourceHash": "047db4c7966a202208d29a815ffed04cce3227f3f477853bed1011c2796d03bf",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -873,14 +873,14 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "findDuplicateOutputName",
           "kind": "function",
-          "line": 60,
+          "line": 68,
           "exported": false,
           "signature": "function findDuplicateOutputName(names: string[], pageNumbers: number[]): { name: string; pages: number[] } | undefined"
         },
         {
           "name": "pdfToPngCore",
           "kind": "function",
-          "line": 84,
+          "line": 96,
           "exported": true,
           "signature": "export async function pdfToPngCore( pdfFile: string | ArrayBufferLike | Uint8Array, normalizedProps: NormalizedPdfToPngOptions, ): Promise<PngPageOutput[]>"
         }

--- a/__tests__/pdf.to.png.duplicate.filename.test.ts
+++ b/__tests__/pdf.to.png.duplicate.filename.test.ts
@@ -124,4 +124,54 @@ describe('VAL-001: duplicate output filename pre-flight check', () => {
 
         expect(await pngFilesIn(outputFolder)).toHaveLength(0);
     });
+
+    test('(h) names differing only in case collide on case-insensitive filesystems and are rejected before any write', async () => {
+        const outputFolder = join(baseOutputFolder, 'case-collision');
+        await fsPromises.mkdir(outputFolder, { recursive: true });
+
+        // "Page.png" and "page.png" are distinct strings but the SAME file on case-insensitive,
+        // case-preserving filesystems (macOS APFS, Windows NTFS — the default dev environments).
+        // The pre-flight check must reject them with the clean VAL-001 error on every platform,
+        // not let the second exclusive-create ('wx') write fail with a raw EEXIST that leaks the
+        // absolute output path and leaves the first file behind.
+        await expect(
+            pdfToPng(multiPagePdfFilePath, {
+                outputFolder,
+                outputFileMaskFunc: (pageNumber: number) => (pageNumber === 1 ? 'Page.png' : 'page.png'),
+                pagesToProcess: [1, 2],
+            }),
+        ).rejects.toThrow(/Duplicate output filename "Page\.png" for pages 1, 2\./);
+
+        expect(await pngFilesIn(outputFolder)).toHaveLength(0);
+    });
+
+    test('(i) case-collision error does not leak the absolute output path', async () => {
+        const outputFolder = join(baseOutputFolder, 'case-no-leak');
+
+        let message = '';
+        try {
+            await pdfToPng(multiPagePdfFilePath, {
+                outputFolder,
+                outputFileMaskFunc: (pageNumber: number) => (pageNumber === 1 ? 'Page.png' : 'page.png'),
+                pagesToProcess: [1, 2],
+            });
+        } catch (error: unknown) {
+            message = error instanceof Error ? error.message : String(error);
+        }
+
+        expect(message).toMatch(/Duplicate output filename/);
+        expect(message).not.toContain(outputFolder);
+        expect(message).not.toContain(process.cwd());
+    });
+
+    test('(j) gating: case-only-differing names with no outputFolder (in-memory) do not throw', async () => {
+        const pages = await pdfToPng(pdfFilePath, {
+            outputFileMaskFunc: (pageNumber: number) => (pageNumber === 1 ? 'Page.png' : 'page.png'),
+            pagesToProcess: [1, 2],
+        });
+
+        expect(pages).toHaveLength(2);
+        expect(pages.map((page) => page.name)).toEqual(['Page.png', 'page.png']);
+        expect(pages.every((page) => page.path === '')).toBe(true);
+    });
 });

--- a/src/pdfToPngCore.ts
+++ b/src/pdfToPngCore.ts
@@ -54,16 +54,28 @@ async function processPagesWithSlidingWindow<T>(
  * `EEXIST` from the exclusive-create (`'wx'`) write — which previously also left the first colliding
  * file on disk and leaked the absolute output path. See VAL-001.
  *
+ * Collision is detected case-insensitively (keys are lower-cased): on case-insensitive,
+ * case-preserving filesystems (macOS APFS, Windows NTFS — the default developer environments)
+ * names such as `Page.png` and `page.png` are the SAME file, so writing both would otherwise slip
+ * past an exact-string check and fail with the very raw `EEXIST` (partial output + leaked absolute
+ * path) this pre-flight exists to prevent. Keying case-insensitively makes the "unique filename"
+ * guarantee hold portably across every platform. The reported `name` is the first-seen original
+ * (case preserved) for an actionable message.
+ *
  * Iterates in first-seen order, so the reported duplicate is deterministic regardless of whether
  * pages are later rendered sequentially or in parallel.
  */
 function findDuplicateOutputName(names: string[], pageNumbers: number[]): { name: string; pages: number[] } | undefined {
-    const pagesByName = new Map<string, number[]>();
+    const pagesByKey = new Map<string, { name: string; pages: number[] }>();
     for (let index = 0; index < names.length; index += 1) {
-        const existing = pagesByName.get(names[index]) ?? [];
-        pagesByName.set(names[index], [...existing, pageNumbers[index]]);
+        const key = names[index].toLowerCase();
+        const existing = pagesByKey.get(key);
+        pagesByKey.set(key, {
+            name: existing?.name ?? names[index],
+            pages: [...(existing?.pages ?? []), pageNumbers[index]],
+        });
     }
-    for (const [name, pages] of pagesByName) {
+    for (const { name, pages } of pagesByKey.values()) {
         if (pages.length > 1) {
             return { name, pages };
         }


### PR DESCRIPTION
## Summary

- Fixed the VAL-001 duplicate-output-filename pre-flight check missing collisions between names that differ only in case (e.g. `Page.png` / `page.png`), which on case-insensitive filesystems are the same file.
- Added regression coverage for case-only-differing names colliding, the error not leaking the absolute output path, and the in-memory gating case.

## Root Cause

`findDuplicateOutputName` in `src/pdfToPngCore.ts` keyed its collision map with **exact string equality** (`pagesByName.get(names[index])`). On case-insensitive, case-preserving filesystems — the default on macOS (APFS) and Windows (NTFS) — `Page.png` and `page.png` resolve to the **same on-disk file**, but as distinct map keys they passed the pre-flight check.

The conversion then proceeded to `savePNGfile` (`src/outputWriter.ts`), which opens with the exclusive-create flag `'wx'`. The first page wrote `Page.png`; the second page's `open('…/page.png', 'wx')` hit the existing file and threw a raw `EEXIST` — leaving the first file on disk and **leaking the absolute output path** in the error message.

That is precisely the partial-output + path-leak failure mode VAL-001 was introduced to eliminate, and it violates the guarantee asserted by existing test `(e)` ("error message does not leak the absolute output path"). Reproduced on macOS:

```
THREW: EEXIST: file already exists, open
'/Users/.../test-results/duplicate-filename/case-no-leak/page.png'
```

(On case-sensitive Linux the two names are genuinely distinct, so both files write and the collision goes undetected — a portability footgun: a conversion that "works" on Linux silently breaks on macOS/Windows.)

## Fix

Key the collision map case-insensitively by lower-casing each resolved name before comparison. The map value now carries the first-seen original name (casing preserved) so the error message stays actionable. The clean `Duplicate output filename "…" for pages …` error is now thrown **before any I/O on every platform**, making the "each processed page must resolve to a unique filename" guarantee hold portably.

Scope is unchanged: the check still only runs when an `outputFolder` is set (disk writes). In-memory / metadata-only conversions still allow repeated names. The diff is confined to `findDuplicateOutputName` plus its doc comment; no public API or signature change.

## Tests

Run in the worktree (`node_modules` symlinked from the main checkout):

- `npm run build:test` — pass (no type errors)
- `npm run build:strict` — pass
- `npm run lint` — pass
- `npm run codemap:check` — pass (CODEMAP regenerated for the shifted line numbers)
- `npm run format:check` — pass
- `npx vitest run` — **222 passed, 2 skipped** (Windows-only), 39 files

New regression tests in `__tests__/pdf.to.png.duplicate.filename.test.ts`:
- `(h)` case-only-differing names are rejected with the clean error and write no files
- `(i)` the error does not leak the absolute output path or cwd
- `(j)` gating: case-only-differing names with no `outputFolder` (in-memory) still succeed

Confirmed `(h)` and `(i)` **fail before** the fix (raw `EEXIST` leaking the absolute path) and **pass after**. They fail before the fix on both case-insensitive (wrong error) and case-sensitive (no error) filesystems, and pass after on both.

## Risk

Low. Behavioral change is limited to a custom `outputFileMaskFunc` that deliberately emits names differing only in case — previously a platform-dependent raw `EEXIST` (or silent acceptance on Linux), now a clean deterministic pre-flight error everywhere. Such names are non-portable by nature. No public API, type, default, or rendered-output change; all 219 pre-existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)