### PR TITLE
test: fix flaky ENOENT from shared output folder between two test files

### DIFF
--- a/__tests__/pdf.as.buffer.to.file.test.ts
+++ b/__tests__/pdf.as.buffer.to.file.test.ts
@@ -8,7 +8,7 @@ import { comparePNG } from './comparePNG';
 test(`should generate png from pdf buffer`, async () => {
     const pdfFilePath: string = resolve('./test-data/sample.pdf');
     const pdfBuffer = readFileSync(pdfFilePath);
-    const outputFolder = resolve('./test-results/sample/actual');
+    const outputFolder = resolve('./test-results/sample-buffer/actual');
     await fsPromises.rm(outputFolder, { recursive: true, force: true });
     const pngPages: PngPageOutput[] = await pdfToPng(pdfBuffer, {
         outputFolder,


### PR DESCRIPTION
## Problem

`__tests__/pdf.as.buffer.to.file.test.ts` intermittently failed with:

```
Error: ENOENT: no such file or directory, open '.../test-results/sample/actual/buffer_page_2.png'
  at __tests__/pdf.as.buffer.to.file.test.ts:21  // readFileSync(pngPage.path)
```

## Root cause — test isolation, not a library bug

Two test files wrote to the **same** output folder `test-results/sample/actual` and each `rm -rf`'d it on entry:

| File | Input | Files written |
|------|-------|---------------|
| `pdf.as.buffer.to.file.test.ts` | buffer | `buffer_page_1.png`, `buffer_page_2.png` |
| `pdf.to.file.sample.test.ts` | path | `sample_page_1.png`, `sample_page_2.png` |

Under Vitest's default parallel-across-files execution, a worker that finished another file could pick up `pdf.to.file.sample` and run its `rm(outputFolder, { recursive: true, force: true })` **while the buffer test was still in its read loop** — deleting the whole folder, including the not-yet-read `buffer_page_2.png`. Hence: page 1 reads fine, page 2 → ENOENT.

It passes in isolation and only flakes in the full suite because the race needs worker *reuse* to stagger the two files. A deterministic reproduction of that interleaving yields the identical error.

## Fix

Give the buffer test its own output folder so the two tests share no mutable state:

```diff
- const outputFolder = resolve('./test-results/sample/actual');
+ const outputFolder = resolve('./test-results/sample-buffer/actual');
```

## Why this is safe / sufficient

- `test-results/` is gitignored scratch — the folder name is arbitrary.
- Only the *output* folder changes, not `pngPage.name`. Reference PNGs are read by name from `test-data/sample/expected/` (which already holds both `buffer_page_*.png` and `sample_page_*.png`), so `comparePNG` is unaffected.
- The two other "shared" folders in the suite are each reused by two `test()` blocks **within a single file**, which Vitest runs sequentially — no race. This was the only genuine cross-file collision.

## Test plan

- [x] `npm run build:test` — clean
- [x] The two formerly-colliding files run together — pass
- [x] Full suite `npm run test:fast` — 39 files, 222 passed / 2 skipped
- [x] Verified no remaining cross-file output-folder collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)