### PR TITLE
fix: emit forward-slash pdf.js factory URLs to unbreak Windows (#173)

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.1.0"
   },
-  "sourceHash": "047db4c7966a202208d29a815ffed04cce3227f3f477853bed1011c2796d03bf",
+  "sourceHash": "c8317449422ca227167c1d4897278760d26e3ab93375f326129adc837b6b43f4",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -493,7 +493,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "normalizePath",
           "kind": "function",
-          "line": 21,
+          "line": 26,
           "exported": true,
           "signature": "export function normalizePath(path: string): string"
         }

--- a/__tests__/normalizePath.test.ts
+++ b/__tests__/normalizePath.test.ts
@@ -5,7 +5,7 @@ test('should normalize path ending with slash', () => {
     const path = '/path/to/folder/';
     const normalizedPath: string = normalizePath(path);
     if (process.platform === 'win32') {
-        expect(normalizedPath).toBe(`${__dirname[0]}:\\path\\to\\folder\\`);
+        expect(normalizedPath).toBe(`${__dirname[0]}:/path/to/folder/`);
     } else {
         expect(normalizedPath).toBe('/path/to/folder/');
     }
@@ -15,7 +15,7 @@ test('should normalize path without ending slash', () => {
     const path = '/path/to/folder';
     const normalizedPath: string = normalizePath(path);
     if (process.platform === 'win32') {
-        expect(normalizedPath).toBe(`${__dirname[0]}:\\path\\to\\folder\\`);
+        expect(normalizedPath).toBe(`${__dirname[0]}:/path/to/folder/`);
     } else {
         expect(normalizedPath).toBe('/path/to/folder/');
     }
@@ -31,17 +31,17 @@ test('should normalize root path', () => {
     const normalizedPath: string = normalizePath(path);
 
     if (process.platform === 'win32') {
-        expect(normalizedPath).toBe(`${__dirname[0]}:\\`);
+        expect(normalizedPath).toBe(`${__dirname[0]}:/`);
     } else {
         expect(normalizedPath).toBe('/');
     }
 });
 
 if (process.platform === 'win32') {
-    test('should append trailing backslash if path ends with backslash on Windows systems', () => {
+    test('should convert Windows separators to forward slashes with a trailing slash', () => {
         const path = `${__dirname[0]}:\\Windows\\`;
         const normalizedPath = normalizePath(path);
-        expect(normalizedPath).toBe(`${__dirname[0]}:\\Windows\\`);
+        expect(normalizedPath).toBe(`${__dirname[0]}:/Windows/`);
     });
 }
 
@@ -49,7 +49,7 @@ test('should normalize path containing spaces', () => {
     const path = '/path/to/my folder/with spaces';
     const normalizedPath: string = normalizePath(path);
     if (process.platform === 'win32') {
-        expect(normalizedPath).toMatch(/my folder\\with spaces\\/);
+        expect(normalizedPath).toMatch(/my folder\/with spaces\//);
     } else {
         expect(normalizedPath).toBe('/path/to/my folder/with spaces/');
     }
@@ -59,7 +59,7 @@ test('should normalize path containing parentheses and special characters', () =
     const path = '/path/to/folder (1)/output';
     const normalizedPath: string = normalizePath(path);
     if (process.platform === 'win32') {
-        expect(normalizedPath).toMatch(/folder \(1\)\\output\\/);
+        expect(normalizedPath).toMatch(/folder \(1\)\/output\//);
     } else {
         expect(normalizedPath).toBe('/path/to/folder (1)/output/');
     }
@@ -69,7 +69,7 @@ test('should preserve spaces in path and ensure trailing separator', () => {
     const path = '/my documents/pdf output';
     const normalizedPath: string = normalizePath(path);
     if (process.platform === 'win32') {
-        expect(normalizedPath.endsWith('\\')).toBe(true);
+        expect(normalizedPath.endsWith('/')).toBe(true);
     } else {
         expect(normalizedPath).toBe('/my documents/pdf output/');
         expect(normalizedPath.endsWith('/')).toBe(true);

--- a/__tests__/normalizePath.win32.test.ts
+++ b/__tests__/normalizePath.win32.test.ts
@@ -1,0 +1,32 @@
+import { expect, test, vi } from 'vitest';
+import { CMAP_RELATIVE_URL, STANDARD_FONTS_RELATIVE_URL } from '../src/const.js';
+import { normalizePath } from '../src/normalizePath.js';
+
+// Regression guard for issue #173: on Windows, `normalizePath` previously appended
+// the OS separator (`\`) to the pdf.js factory URLs (`cMapUrl` / `standardFontDataUrl`),
+// which pdf.js rejects with `Invalid factory url ... must include trailing slash.`.
+// CI only runs on ubuntu-latest, so the Windows separator never surfaced there.
+//
+// This test forces Windows path semantics on any host by binding `node:path` to
+// `path.win32`, then asserts the pdf.js contract directly: the value must end with a
+// forward slash `/` and contain no backslashes. The buggy `${sep}` implementation
+// produces a `\`-terminated string and fails this test on Linux/macOS.
+//
+// `vi.mock` is hoisted above the imports above by Vitest, so `normalizePath` binds to
+// the win32 path implementation.
+vi.mock('node:path', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:path')>();
+    return { ...actual.win32, default: actual.win32 };
+});
+
+test('cMapUrl is a forward-slash, trailing-slash factory URL under Windows path semantics', () => {
+    const result: string = normalizePath(CMAP_RELATIVE_URL);
+    expect(result.endsWith('/')).toBe(true);
+    expect(result).not.toContain('\\');
+});
+
+test('standardFontDataUrl is a forward-slash, trailing-slash factory URL under Windows path semantics', () => {
+    const result: string = normalizePath(STANDARD_FONTS_RELATIVE_URL);
+    expect(result.endsWith('/')).toBe(true);
+    expect(result).not.toContain('\\');
+});

--- a/src/normalizePath.ts
+++ b/src/normalizePath.ts
@@ -1,32 +1,33 @@
 import { normalize, resolve, sep } from 'node:path';
 
 /**
- * Resolves a path to an absolute path and ensures it ends with a trailing path separator.
+ * Resolves a path to an absolute pdf.js factory URL (`cMapUrl` / `standardFontDataUrl`).
  *
  * Internally calls `resolve()` to convert the input to an absolute path (relative to `process.cwd()`),
- * then `normalize()` to collapse any redundant separators or `.` / `..` segments.
- * A trailing `path.sep` is appended if not already present. On POSIX systems this is `/`;
- * on Windows it is `\`. Both are required for pdfjs URL-style paths (`cMapUrl`,
- * `standardFontDataUrl`) and for general filesystem path correctness on each platform.
+ * then `normalize()` to collapse any redundant separators or `.` / `..` segments, then rewrites the
+ * OS separator to a forward slash and guarantees a trailing `/`.
+ *
+ * The trailing character MUST be a forward slash `/` on every platform: pdf.js validates these values
+ * with `getFactoryUrlProp`, which throws `Invalid factory url ... must include trailing slash.` for any
+ * other terminator. The intermediate separators are forward-slashed too, since pdf.js reads the asset
+ * via a bare `fs.readFile(\`${baseUrl}${filename}\`)` and Node accepts `/` on Windows. Do NOT change the
+ * terminator back to `path.sep`: on Windows that yields a `\`-terminated value and breaks every
+ * conversion (see issue #173). This function's only consumer is `propsToPdfDocInitParams`.
  *
  * @param path - The path to normalize. Must be a non-empty string.
- * @returns The resolved, normalized path with a guaranteed trailing platform separator.
+ * @returns The resolved, forward-slashed absolute path with a guaranteed trailing `/`.
  * @throws {Error} If `path` is an empty string.
  *
  * @example
  * normalizePath('./node_modules/pdfjs-dist/cmaps/');
  * // POSIX:   '/absolute/path/to/project/node_modules/pdfjs-dist/cmaps/'
- * // Windows: 'C:\\absolute\\path\\to\\project\\node_modules\\pdfjs-dist\\cmaps\\'
+ * // Windows: 'C:/absolute/path/to/project/node_modules/pdfjs-dist/cmaps/'
  */
 export function normalizePath(path: string): string {
     if (path === '') {
         throw new Error('Path cannot be empty');
     }
-    const resolvedPath: string = normalize(resolve(path));
+    const resolvedPath: string = normalize(resolve(path)).split(sep).join('/');
 
-    if (resolvedPath.endsWith('/') || resolvedPath.endsWith(sep)) {
-        return resolvedPath;
-    }
-
-    return `${resolvedPath}${sep}`;
+    return resolvedPath.endsWith('/') ? resolvedPath : `${resolvedPath}/`;
 }


### PR DESCRIPTION
## Summary

Fixes #173. On **Windows**, every `pdfToPng()` call and CLI invocation threw

```
Invalid factory url: "C:\...\node_modules\pdfjs-dist\cmaps\" must include trailing slash.
```

before any rendering — for all inputs, including `returnMetadataOnly: true`. The library was completely unusable on Windows.

**Root cause:** `normalizePath()` appended the OS path separator (`\` on Windows) to the `cMapUrl` / `standardFontDataUrl` values handed to pdf.js. pdf.js's `getFactoryUrlProp` requires a trailing forward slash `/` on **every** platform and rejects anything else. This reverts the *intent* of `53a5bb2`, which switched the terminator to `${sep}` to guard a hypothetical OS-filesystem consumer that never existed.

**Why this is safe:** `normalizePath`'s only production consumer is `propsToPdfDocInitParams` (the two pdf.js URLs) — it has **no** on-disk/output-folder consumers (those use `path.join` directly), so the issue's blast-radius warning about regressing `outputWriter`/`FilesystemSink`/SEC guards does not apply. pdf.js reads the asset via a bare `fs.readFile(\`${baseUrl}${filename}\`)` (no `new URL()`), and Node accepts forward slashes on Windows, so emitting a fully forward-slashed, `/`-terminated value is correct. **POSIX output is byte-identical to before.**

## Changes

- **`src/normalizePath.ts`** — `normalize(resolve(path)).split(sep).join('/')`, guarantee a trailing `/`. Docstring rewritten to document the pdf.js factory-URL contract and warn against reintroducing `${sep}`.
- **`__tests__/normalizePath.win32.test.ts`** (new) — POSIX-runnable regression guard: binds `node:path` to `path.win32` and asserts the value ends with `/` and contains no `\`. Proven **red → green** against the old implementation. This is the test that was missing — see CI note.
- **`__tests__/normalizePath.test.ts`** — updated the `win32` assertions (which encoded `\`-terminated output as correct) to expect forward-slash, `/`-terminated output.

## Why CI missed it

CI runs only on `ubuntu-latest`, where `path.sep === '/'`, so the buggy `${sep}` produced a valid `/`-terminator. A POSIX-only assertion can't catch this (the bug is invisible when `sep` is already `/`); the new `win32`-mock test forces Windows path semantics on the Linux runner and catches it there.

**Native `windows-latest` CI deferred to #178.** I attempted to add a Windows job, but `npm ci` fails on Windows with `EBADPLATFORM` because the test-only devDependency `png-visual-compare@6.1.0` declares `os: [darwin, linux]`. That's an unrelated test-toolchain blocker (end users are unaffected — it's a devDependency), so it's split into #178. The `win32`-mock test in this PR already guards #173 on the existing ubuntu runner.

## Test plan

- [x] `npm test` (full suite + coverage) green on macOS — 224 passed, 2 skipped (Windows-only cases), 98.47% statements
- [x] New regression test verified red against old code, green after fix
- [x] `npm run build:test`, `npm run lint` clean
- [ ] CI green on `ubuntu-latest`