### PR TITLE
chore(release): 4.1.1 with OIDC trusted publishing and release checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,9 +23,16 @@ jobs:
                   node-version-file: .nvmrc
                   cache: 'npm'
                   registry-url: 'https://registry.npmjs.org'
+            # Trusted Publishing (OIDC) needs npm >= 11.5.1; pin to the packageManager version.
+            - run: npm install -g npm@11.13.0
             - run: npm ci
             - run: npm audit --audit-level=high
             - run: npm run build
-            - run: npm publish
+            - name: Pre-release checks
+              run: npm run release:precheck
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  RELEASE_TAG: ${{ github.event.release.tag_name }}
+            # No NODE_AUTH_TOKEN: npm authenticates via OIDC trusted publishing and attaches provenance.
+            - run: npm publish --provenance
+            - name: Post-release checks
+              run: npm run release:postcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.1] — 2026-06-19
+
 ### Fixed
 
+- pdf.js CMap and standard-font factory URLs (`cMapUrl` / `standardFontDataUrl`) are now always emitted with forward slashes and a guaranteed trailing `/`, fixing every conversion on Windows. `normalizePath()` previously appended the OS path separator, so on Windows it produced a `\`-terminated, backslash-separated value; pdf.js validates these factory URLs with `getFactoryUrlProp`, which throws `Invalid factory url … must include trailing slash.` for any non-`/` terminator, breaking all rendering on Windows. POSIX output is byte-identical to before (the separator was already `/`). Resolves issue #173.
 - The duplicate-output-filename pre-flight check (VAL-001) now detects collisions **case-insensitively**. Previously it compared resolved page filenames with exact string equality, so two names differing only in case (e.g. an `outputFileMaskFunc` returning `Page.png` for one page and `page.png` for another) passed the check. On case-insensitive, case-preserving filesystems — the default on macOS (APFS) and Windows (NTFS) — those names are the **same file**, so the second exclusive-create (`'wx'`) write failed with a raw `EEXIST` that left the first file on disk and **leaked the absolute output path** in the error message — exactly the partial-output + path-leak failure mode VAL-001 was introduced to prevent. The pre-flight now lower-cases names when keying, so the clean `Duplicate output filename "…" for pages …` error is thrown before any I/O on every platform; the reported name preserves the first-seen original casing. In-memory / metadata-only conversions (no `outputFolder`) still allow repeated names. This makes the "each processed page must resolve to a unique filename" guarantee hold portably regardless of the host filesystem.
 
 ### Changed

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -8,7 +8,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
   "schema": "codemap.v2",
   "repo": {
     "name": "pdf-to-png-converter",
-    "version": "4.1.0"
+    "version": "4.1.1"
   },
   "sourceHash": "c8317449422ca227167c1d4897278760d26e3ab93375f326129adc837b6b43f4",
   "entrypoints": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,20 @@ Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
 - [ ] New behaviour is covered by tests (coverage thresholds: lines 90%, functions 90%, branches 85%)
 - [ ] `CHANGELOG.md` updated under `## [Unreleased]` (or moved into the release section when cutting a release)
 
+## Releasing
+
+Releases are published to npm by `.github/workflows/publish.yml` when a GitHub Release is **published**. Publishing uses npm **Trusted Publishing (OIDC)** — there is no long-lived `NPM_TOKEN`; the workflow mints a short-lived token and attaches build [provenance](https://docs.npmjs.com/generating-provenance-statements) automatically.
+
+**One-time setup (maintainer):** on npmjs.com, configure the package's _Trusted Publisher_ to GitHub Actions for `dichovsky/pdf-to-png-converter`, workflow `publish.yml` (leave _Environment_ blank).
+
+**Cutting a release:**
+
+1. On a release branch, bump the version with `npm version <x.y.z> --no-git-tag-version` (updates `package.json` + `package-lock.json`).
+2. Move the `## [Unreleased]` entries in `CHANGELOG.md` into a new `## [x.y.z] — <date>` section.
+3. Run `npm run release:precheck` locally (after `npm run build`) to validate the version is unpublished, the CHANGELOG entry exists, and the tarball ships only `out/`.
+4. Merge the branch, then create a GitHub Release tagged `vx.y.z`.
+5. The workflow runs `release:precheck` → `npm publish --provenance` → `release:postcheck` (verifies the published version, the `latest` dist-tag, the provenance attestation, and a clean-install smoke test).
+
 ## Reporting Bugs / Security Issues
 
 - **Bugs:** open a [GitHub issue](https://github.com/dichovsky/pdf-to-png-converter/issues)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pdf-to-png-converter",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pdf-to-png-converter",
-            "version": "4.1.0",
+            "version": "4.1.1",
             "license": "MIT",
             "dependencies": {
                 "@napi-rs/canvas": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pdf-to-png-converter",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "description": "Node.js utility to convert PDF file/buffer pages to PNG files/buffers. No build-time compilation required — pre-built native binaries included for all major platforms.",
     "keywords": [
         "pdf",
@@ -60,6 +60,8 @@
         "prepare": "husky",
         "prepublishOnly": "npm test && npm run build",
         "pretest": "npm run clean && npm run build:test && npm run build:strict && npm run codemap:check && npm run format:check && npm run lint && npm run test:license",
+        "release:precheck": "ts-node scripts/release-precheck.ts",
+        "release:postcheck": "ts-node scripts/release-postcheck.ts",
         "test": "vitest run --coverage",
         "test:docker": "npm run clean && npm run docker:build && npm run docker:run",
         "test:fast": "vitest run --reporter=dot --no-coverage",

--- a/scripts/release-postcheck.ts
+++ b/scripts/release-postcheck.ts
@@ -1,0 +1,153 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Detective release verification. Run by `publish.yml` immediately after `npm publish`
+// to confirm the publish actually landed with provenance and is consumable. The publish
+// has already happened by this point, so a failure here is an alarm, not a gate — it
+// surfaces a broken OIDC/provenance/propagation pipeline loudly. Registry reads are
+// retried to absorb propagation lag.
+
+interface PackageManifest {
+    name: string;
+    version: string;
+}
+
+interface Attestations {
+    url?: string;
+    provenance?: unknown;
+}
+
+interface DistInfo {
+    attestations?: Attestations;
+}
+
+interface PackumentVersion {
+    dist?: DistInfo;
+}
+
+const NPM: string = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const REPO_ROOT: string = join(__dirname, '..');
+const RETRY_ATTEMPTS = 10;
+const RETRY_DELAY_MS = 3000;
+
+function readManifest(): PackageManifest {
+    const raw: string = readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<PackageManifest>;
+    if (typeof parsed.name !== 'string' || typeof parsed.version !== 'string') {
+        throw new Error('package.json is missing a string "name" or "version"');
+    }
+    return { name: parsed.name, version: parsed.version };
+}
+
+function runNpm(args: string[], cwd?: string): string {
+    return execFileSync(NPM, args, { encoding: 'utf-8', cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Retry a registry read until it returns a non-null value, absorbing propagation lag.
+async function retry<T>(label: string, fn: () => T | null): Promise<T> {
+    for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt += 1) {
+        const value = fn();
+        if (value !== null) {
+            return value;
+        }
+        if (attempt < RETRY_ATTEMPTS) {
+            await sleep(RETRY_DELAY_MS);
+        }
+    }
+    throw new Error(`${label}: still unavailable after ${RETRY_ATTEMPTS} attempts`);
+}
+
+// Q1 — the exact version is resolvable on the registry.
+function fetchPublishedVersion(name: string, version: string): string | null {
+    try {
+        const out = runNpm(['view', `${name}@${version}`, 'version', '--json']).trim();
+        return out.length > 0 ? (JSON.parse(out) as string) : null;
+    } catch {
+        return null;
+    }
+}
+
+// Q2 — the `latest` dist-tag points at the new version.
+function fetchLatestDistTag(name: string): string | null {
+    try {
+        const out = runNpm(['view', name, 'dist-tags.latest', '--json']).trim();
+        return out.length > 0 ? (JSON.parse(out) as string) : null;
+    } catch {
+        return null;
+    }
+}
+
+// Q3 — the published version carries a provenance attestation.
+function fetchAttestations(name: string, version: string): Attestations | null {
+    try {
+        const out = runNpm(['view', `${name}@${version}`, '--json']).trim();
+        if (out.length === 0) {
+            return null;
+        }
+        const packument = JSON.parse(out) as PackumentVersion;
+        return packument.dist?.attestations ?? null;
+    } catch {
+        return null;
+    }
+}
+
+// Q4 — a clean install of the published version loads and exposes a working CLI.
+function smokeTestInstall(name: string, version: string): void {
+    const dir = mkdtempSync(join(tmpdir(), 'p2p-smoke-'));
+    try {
+        runNpm(['init', '-y'], dir);
+        runNpm(['install', `${name}@${version}`, '--no-audit', '--no-fund'], dir);
+        execFileSync(
+            process.execPath,
+            ['-e', `if (typeof require(${JSON.stringify(name)}).pdfToPng !== 'function') { process.exit(3); }`],
+            { cwd: dir, stdio: ['ignore', 'pipe', 'pipe'] },
+        );
+        const binPath = join(dir, 'node_modules', '.bin', name);
+        const cliOutput = execFileSync(binPath, ['--version'], { encoding: 'utf-8' }).trim();
+        if (cliOutput !== `v${version}`) {
+            throw new Error(`CLI --version printed "${cliOutput}", expected "v${version}"`);
+        }
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+}
+
+async function main(): Promise<void> {
+    const { name, version } = readManifest();
+    console.log(`release:postcheck for ${name}@${version}`);
+
+    const publishedVersion = await retry('Q1 published version', () => fetchPublishedVersion(name, version));
+    if (publishedVersion !== version) {
+        throw new Error(`Q1 npm reports version "${publishedVersion}", expected "${version}"`);
+    }
+    console.log(`  Q1 published version:      OK (${publishedVersion})`);
+
+    const latest = await retry('Q2 dist-tag latest', () => fetchLatestDistTag(name));
+    if (latest !== version) {
+        throw new Error(`Q2 dist-tag "latest" is "${latest}", expected "${version}"`);
+    }
+    console.log(`  Q2 dist-tag latest:        OK (${latest})`);
+
+    const attestations = await retry('Q3 provenance attestation', () => fetchAttestations(name, version));
+    if (attestations.url === undefined && attestations.provenance === undefined) {
+        throw new Error('Q3 published version has no provenance attestation');
+    }
+    console.log('  Q3 provenance attestation: OK');
+
+    smokeTestInstall(name, version);
+    console.log('  Q4 clean-install smoke:    OK');
+
+    console.log('\nrelease:postcheck PASSED');
+}
+
+main().catch((err: unknown) => {
+    console.error('\nrelease:postcheck FAILED:');
+    console.error(`  x ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+});

--- a/scripts/release-precheck.ts
+++ b/scripts/release-precheck.ts
@@ -1,0 +1,139 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Preventive release gate. Run by `publish.yml` immediately before `npm publish`
+// (and locally as a pre-flight) to block a release whose version, changelog, or
+// packaged contents are wrong. All checks accumulate; the process exits non-zero
+// listing every failure rather than stopping at the first.
+
+interface PackageManifest {
+    name: string;
+    version: string;
+}
+
+interface PackedFile {
+    path: string;
+}
+
+interface PackResult {
+    files: PackedFile[];
+}
+
+const NPM: string = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const REPO_ROOT: string = join(__dirname, '..');
+const REQUIRED_TARBALL_FILES: readonly string[] = ['out/index.js', 'out/index.d.ts', 'out/cli.js'];
+
+function readManifest(): PackageManifest {
+    const raw: string = readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<PackageManifest>;
+    if (typeof parsed.name !== 'string' || typeof parsed.version !== 'string') {
+        throw new Error('package.json is missing a string "name" or "version"');
+    }
+    return { name: parsed.name, version: parsed.version };
+}
+
+function runNpm(args: string[]): string {
+    return execFileSync(NPM, args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+// P1 — the GitHub Release tag must match the package version being published.
+function checkTagMatchesVersion(version: string, failures: string[]): void {
+    const tag: string | undefined = process.env.RELEASE_TAG;
+    if (tag === undefined || tag === '') {
+        console.log('  P1 tag matches version:   SKIPPED (no RELEASE_TAG; local run)');
+        return;
+    }
+    const expected = `v${version}`;
+    if (tag !== expected) {
+        failures.push(`P1 release tag "${tag}" does not match package version "${expected}"`);
+        return;
+    }
+    console.log(`  P1 tag matches version:   OK (${tag})`);
+}
+
+// P2 — the version must not already exist on the registry (fail fast on a double publish).
+function checkNotAlreadyPublished(name: string, version: string, failures: string[]): void {
+    let published: string | null = null;
+    try {
+        const out = runNpm(['view', `${name}@${version}`, 'version', '--json']).trim();
+        published = out.length > 0 ? (JSON.parse(out) as string) : null;
+    } catch (err) {
+        const text = err instanceof Error ? err.message : String(err);
+        if (!text.includes('E404')) {
+            failures.push(`P2 could not query npm for ${name}@${version}: ${text}`);
+            return;
+        }
+    }
+    if (published === version) {
+        failures.push(`P2 ${name}@${version} is already published to npm — bump the version`);
+        return;
+    }
+    console.log(`  P2 version is unpublished: OK (${name}@${version} is new)`);
+}
+
+// P3 — CHANGELOG.md must carry a section for this version (no release without notes).
+function checkChangelogEntry(version: string, failures: string[]): void {
+    const changelog = readFileSync(join(REPO_ROOT, 'CHANGELOG.md'), 'utf-8');
+    const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const heading = new RegExp(`^##\\s*\\[${escaped}\\]`, 'm');
+    if (!heading.test(changelog)) {
+        failures.push(`P3 CHANGELOG.md has no "## [${version}]" section`);
+        return;
+    }
+    console.log(`  P3 CHANGELOG entry exists: OK ([${version}])`);
+}
+
+// P4 — the published tarball must ship the build output and nothing else (no source, tests, or tsbuildinfo).
+function checkTarballContents(failures: string[]): void {
+    let files: string[];
+    try {
+        const out = runNpm(['pack', '--dry-run', '--ignore-scripts', '--json']);
+        const start = out.indexOf('[');
+        if (start === -1) {
+            throw new Error('no JSON array in "npm pack" output');
+        }
+        const result = JSON.parse(out.slice(start)) as PackResult[];
+        files = result[0].files.map((file) => file.path.replace(/\\/g, '/'));
+    } catch (err) {
+        failures.push(`P4 could not inspect the tarball: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+    }
+    const missing = REQUIRED_TARBALL_FILES.filter((required) => !files.includes(required));
+    if (missing.length > 0) {
+        failures.push(`P4 tarball is missing required files: ${missing.join(', ')}`);
+    }
+    const forbidden = files.filter(
+        (file) =>
+            file.startsWith('src/') ||
+            file.includes('__tests__/') ||
+            file.endsWith('.tsbuildinfo') ||
+            (file.endsWith('.ts') && !file.endsWith('.d.ts')),
+    );
+    if (forbidden.length > 0) {
+        failures.push(`P4 tarball contains files that should not ship: ${forbidden.join(', ')}`);
+    }
+    if (missing.length === 0 && forbidden.length === 0) {
+        console.log(`  P4 tarball contents:       OK (${files.length} files)`);
+    }
+}
+
+function main(): void {
+    const { name, version } = readManifest();
+    console.log(`release:precheck for ${name}@${version}`);
+    const failures: string[] = [];
+    checkTagMatchesVersion(version, failures);
+    checkNotAlreadyPublished(name, version, failures);
+    checkChangelogEntry(version, failures);
+    checkTarballContents(failures);
+    if (failures.length > 0) {
+        console.error('\nrelease:precheck FAILED:');
+        for (const failure of failures) {
+            console.error(`  x ${failure}`);
+        }
+        process.exit(1);
+    }
+    console.log('\nrelease:precheck PASSED');
+}
+
+main();


### PR DESCRIPTION
## Summary

Prepares the **4.1.1** release and switches npm publishing to **OIDC Trusted Publishing** (passwordless) with build provenance, plus adds pre/post release-integrity checks.

### 1. OIDC Trusted Publishing — `.github/workflows/publish.yml`
- Authenticate via OIDC trusted publishing instead of `NODE_AUTH_TOKEN` / `NPM_TOKEN` (secret removed from the step).
- Pin npm to `11.13.0` (== `packageManager`, ≥ 11.5.1 required for trusted publishing).
- `npm publish --provenance` (fail-loud attestation).
- Run `release:precheck` before publish (gate) and `release:postcheck` after (verify).
- `id-token: write` was already present; no GitHub Environment (kept minimal for the first cutover).

### 2. Release-integrity checks — `scripts/release-precheck.ts`, `scripts/release-postcheck.ts`
TypeScript via ts-node (matches `generate-codemap.ts`); wired as `release:precheck` / `release:postcheck`; runnable in CI **and** locally.

| precheck (gate) | postcheck (verify) |
|---|---|
| P1 release tag == package version | Q1 published version resolves on npm |
| P2 version not already published | Q2 `latest` dist-tag == version |
| P3 CHANGELOG `## [version]` exists | Q3 provenance attestation present |
| P4 tarball ships only `out/` (no src/tests/tsbuildinfo) | Q4 clean-install smoke test (`require()` + CLI `--version`) |

### 3. Version 4.1.0 → 4.1.1
- `package.json` + `package-lock.json` bumped; `CODEMAP.md` regenerated (version line).
- CHANGELOG: `[Unreleased]` → `## [4.1.1] — 2026-06-19`, **adding the missing #173** Windows forward-slash factory-URL fix.
- Release flow documented in `CONTRIBUTING.md`.

Patch bump justified: all changes since `v4.1.0` are bug fixes / packaging chores; no public-API (`src/index.ts`, `src/interfaces/`, `src/const.ts` unchanged) or runtime-dependency changes.

## ⚠️ Required manual steps (maintainer-owned)
1. **Before the first OIDC release:** on npmjs.com configure Package → Settings → **Trusted Publisher** → GitHub Actions: repo `dichovsky/pdf-to-png-converter`, workflow `publish.yml`, **Environment blank**. Without this the publish fails (no token fallback).
2. **After the first green OIDC publish:** revoke the old npm publish token and delete the `NPM_TOKEN` GitHub secret.

## Test plan / verification (run locally)
- [x] `npm run build`
- [x] `npm run build:test` (type-check src + tests)
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run codemap:check` (regenerated)
- [x] `npm run release:precheck` → PASSED (P2/P3/P4 green, 47-file tarball; P1 verified pass + fail with `RELEASE_TAG`)
- [x] both scripts type-clean (ts-node + standalone tsc)
- [ ] `release:postcheck` exercises live npm registry — validated end-to-end by the publish workflow on the real release

## Release sequence (after merge)
PR merged → **you confirm npmjs.com Trusted Publisher is configured** → I run `gh release create v4.1.1` → workflow runs precheck → `npm publish --provenance` → postcheck.