### PR TITLE
docs: update copilot-instructions publish flow to OIDC

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -325,10 +325,11 @@ for (const testData of testDataArray) {
 - Ubuntu only, Node 24
 - Steps: `npm ci` → `npm run build:test && npm run lint` → `npm test`
 
-**`publish.yml`** — runs on GitHub release creation:
+**`publish.yml`** — runs when a GitHub release is published:
 
 - Ubuntu, Node 24.x
-- Steps: `npm ci` → `npm run build` → `npm publish` (uses `NPM_TOKEN` secret)
+- Auth via npm **Trusted Publishing (OIDC)** — no `NPM_TOKEN`; `id-token: write` mints a short-lived token and attaches provenance
+- Steps: pin `npm@11.13.0` → `npm ci` → `npm audit` → `npm run build` → `release:precheck` → `npm publish --provenance` → `release:postcheck`
 
 ## Dependencies
 


### PR DESCRIPTION
Follow-up to #186. The Copilot instructions still described the old token-based publish (`npm publish` using the `NPM_TOKEN` secret). Updated the `publish.yml` summary to reflect npm Trusted Publishing (OIDC): no `NPM_TOKEN`, `id-token: write` mints a short-lived token + provenance, and the full step sequence (npm pin → ci → audit → build → release:precheck → publish --provenance → release:postcheck).

Docs-only; no code or workflow change.