### PR TITLE
perf: overlap PNG encode and disk writes with page rendering (−40% on text-heavy PDFs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ dist
 # IntelliJ IDEA files
 .idea
 *.iml
+bench-results

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Published to npm as `pdf-to-png-converter`. Entry: `out/index.js`, types: `out/i
 
 **Single validation boundary:** `normalizePdfToPngOptions` produces `NormalizedPdfToPngOptions`, which is consumed by `pdfToPngCore`, `getPdfDocument`, and `propsToPdfDocInitParams`. No downstream module re-applies `??` defaults — all defaulting happens in the normalizer.
 
-**Concurrency:** when `processPagesInParallel: true`, pages are chunked into batches of `concurrencyLimit` (default 4) and each batch runs via `Promise.all`. Sequential (default) processes pages one at a time.
+**Concurrency:** all conversions run through a sliding window (`processPagesWithSlidingWindow` in `src/pdfToPngCore.ts`). Parallel mode (`processPagesInParallel: true`) uses a window of `concurrencyLimit` (default 4); sequential (default) uses a fixed window of 2 (`SEQUENTIAL_PIPELINE_WINDOW`) so the off-thread PNG encode (async `canvas.encode('png')` on the libuv threadpool) and disk write of page N overlap the render of page N+1. Output order is preserved in both modes.
 
 **`outputFolder` + `returnPageContent` + `returnMetadataOnly` interaction:**
 

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.1.1"
   },
-  "sourceHash": "a2c56ce791ede7f2f33264dcba9e4244e5c37627c4df033c43d9db85fec362d2",
+  "sourceHash": "c08a02effbdea3abf2652edbd2f60447106d1c982a09ae07c2bad46b8bbcf486",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -235,30 +235,37 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
           "signature": "export const MAX_CONCURRENCY_LIMIT = 16"
         },
         {
+          "name": "SEQUENTIAL_PIPELINE_WINDOW",
+          "kind": "variable",
+          "line": 41,
+          "exported": true,
+          "signature": "export const SEQUENTIAL_PIPELINE_WINDOW = 2"
+        },
+        {
           "name": "PDF_TO_PNG_OPTIONS_DEFAULTS",
           "kind": "variable",
-          "line": 39,
+          "line": 47,
           "exported": true,
           "signature": "export const PDF_TO_PNG_OPTIONS_DEFAULTS = { viewportScale: 1, disableFontFace: true, useSystemFonts: false, enableXfa: true, outputFileMask: 'buffer', pdfFilePassword: undefined, concurrencyLimit: 4,…"
         },
         {
           "name": "CMAP_RELATIVE_URL",
           "kind": "variable",
-          "line": 58,
+          "line": 66,
           "exported": true,
           "signature": "export const CMAP_RELATIVE_URL = './node_modules/pdfjs-dist/cmaps/'"
         },
         {
           "name": "STANDARD_FONTS_RELATIVE_URL",
           "kind": "variable",
-          "line": 59,
+          "line": 67,
           "exported": true,
           "signature": "export const STANDARD_FONTS_RELATIVE_URL = './node_modules/pdfjs-dist/standard_fonts/'"
         },
         {
           "name": "DOCUMENT_INIT_PARAMS_DEFAULTS",
           "kind": "variable",
-          "line": 71,
+          "line": 79,
           "exported": true,
           "signature": "export const DOCUMENT_INIT_PARAMS_DEFAULTS: DocumentInitParameters = { cMapUrl: CMAP_RELATIVE_URL, cMapPacked: true, standardFontDataUrl: STANDARD_FONTS_RELATIVE_URL, }"
         }
@@ -719,56 +726,56 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "CanvasFactory",
           "kind": "interface",
-          "line": 14,
+          "line": 15,
           "exported": false,
           "signature": "interface CanvasFactory { create(width: number, height: number): CanvasAndContext; destroy(canvasAndContext: CanvasAndContext): void; }"
         },
         {
           "name": "isCanvasFactory",
           "kind": "function",
-          "line": 25,
+          "line": 26,
           "exported": false,
           "signature": "function isCanvasFactory(factory: unknown): factory is CanvasFactory"
         },
         {
           "name": "toPixelDimension",
           "kind": "function",
-          "line": 46,
+          "line": 47,
           "exported": true,
           "signature": "export function toPixelDimension(viewportLength: number): number"
         },
         {
           "name": "nonRenderableDimensionsError",
           "kind": "function",
-          "line": 60,
+          "line": 61,
           "exported": true,
           "signature": "export function nonRenderableDimensionsError(width: number, height: number): Error"
         },
         {
           "name": "canvasPixelLimitError",
           "kind": "function",
-          "line": 79,
+          "line": 80,
           "exported": true,
           "signature": "export function canvasPixelLimitError(canvasWidth: number, canvasHeight: number): Error"
         },
         {
           "name": "normalizeRotation",
           "kind": "function",
-          "line": 89,
+          "line": 90,
           "exported": true,
           "signature": "export function normalizeRotation(raw: number): PageRotation"
         },
         {
           "name": "getPageMetadata",
           "kind": "function",
-          "line": 105,
+          "line": 106,
           "exported": true,
           "signature": "export async function getPageMetadata( pdf: PDFDocumentProxy, pageName: string, pageNumber: number, pageViewportScale: number, ): Promise<MetadataPngPageOutput>"
         },
         {
           "name": "renderPdfPage",
           "kind": "function",
-          "line": 140,
+          "line": 141,
           "exported": true,
           "signature": "export async function renderPdfPage( pdf: PDFDocumentProxy, pageName: string, pageNumber: number, pageViewportScale: number, returnPageContent: boolean, ): Promise<InMemoryPngPageOutput>"
         }
@@ -889,7 +896,8 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "from": "./const.js",
           "names": [
-            "PDF_TO_PNG_OPTIONS_DEFAULTS"
+            "PDF_TO_PNG_OPTIONS_DEFAULTS",
+            "SEQUENTIAL_PIPELINE_WINDOW"
           ]
         },
         {

--- a/__tests__/coverage.test.ts
+++ b/__tests__/coverage.test.ts
@@ -213,7 +213,7 @@ describe('pdfToPng', () => {
 
     it('passes the exact object returned by create() into destroy() so pdf.js-internal fields survive', async () => {
         const created = {
-            canvas: { toBuffer: vi.fn().mockReturnValue(Buffer.alloc(1)) },
+            canvas: { encode: vi.fn().mockResolvedValue(Buffer.alloc(1)) },
             context: {},
             // A field pdf.js may attach for its own cleanup; it must survive the round-trip.
             _pdfjsInternal: Symbol('internal'),
@@ -248,7 +248,7 @@ describe('pdfToPng', () => {
     it('should throw when outputFolder directory resolves outside outputFolder via symlink (symlink escape on dirname)', async () => {
         // Simulates a symlink swap: the filename is safe-looking but realpath(dirname(file))
         // resolves to a path outside realOutputFolder — L458 in savePNGfile.
-        const mockCanvas = { toBuffer: vi.fn().mockReturnValue(Buffer.alloc(0)) };
+        const mockCanvas = { encode: vi.fn().mockResolvedValue(Buffer.alloc(0)) };
         const mockCanvasFactory = {
             create: vi.fn().mockReturnValue({ canvas: mockCanvas, context: {} }),
             destroy: vi.fn(),
@@ -283,9 +283,9 @@ describe('pdfToPng', () => {
     });
 
     it('should throw when content is undefined at write time (defensive guard)', async () => {
-        // Simulates canvas.toBuffer() returning undefined (e.g. broken canvas implementation).
+        // Simulates canvas.encode() resolving to undefined (e.g. broken canvas implementation).
         // Guards L463: the savePNGfile defensive check that content must not be undefined.
-        const mockCanvas = { toBuffer: vi.fn().mockReturnValue(undefined) };
+        const mockCanvas = { encode: vi.fn().mockResolvedValue(undefined) };
         const mockCanvasFactory = {
             create: vi.fn().mockReturnValue({ canvas: mockCanvas, context: {} }),
             destroy: vi.fn(),
@@ -320,7 +320,7 @@ describe('pdfToPng', () => {
     it('should throw when output folder realpath changes between initial check and final write', async () => {
         // Simulate a TOCTOU swap: realpath returns the same value for the initial containment
         // checks (passes), then a different value for the final re-verification (triggers error).
-        const mockCanvas = { toBuffer: vi.fn().mockReturnValue(Buffer.alloc(0)) };
+        const mockCanvas = { encode: vi.fn().mockResolvedValue(Buffer.alloc(0)) };
         const mockCanvasFactory = {
             create: vi.fn().mockReturnValue({ canvas: mockCanvas, context: {} }),
             destroy: vi.fn(),

--- a/__tests__/input.file.zero.copy.test.ts
+++ b/__tests__/input.file.zero.copy.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { getPdfFileBuffer } from '../src/pdfInput';
+
+vi.mock('node:fs', () => ({
+    promises: { stat: vi.fn(), readFile: vi.fn() },
+}));
+
+import { promises as fsPromises } from 'node:fs';
+
+const statMock = vi.mocked(fsPromises.stat);
+const readFileMock = vi.mocked(fsPromises.readFile);
+
+function mockStat(size: number): void {
+    statMock.mockResolvedValue({ isFile: () => true, size } as never);
+}
+
+afterEach(() => {
+    vi.resetAllMocks();
+});
+
+test('file-path input hands the readFile buffer to pdfjs without copying when it spans its ArrayBuffer', async () => {
+    // Buffer.alloc yields a full-span, non-pooled Buffer — the normal readFile shape.
+    const raw = Buffer.alloc(8, 7);
+    mockStat(raw.byteLength);
+    readFileMock.mockResolvedValue(raw as never);
+
+    const result = await getPdfFileBuffer('/fake/file.pdf', 1024);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    // Zero-copy: the returned view shares the readFile buffer's memory.
+    expect((result as Uint8Array).buffer).toBe(raw.buffer);
+    expect(Array.from(result as Uint8Array)).toEqual(Array.from(raw));
+});
+
+test('file-path input copies when the readFile buffer starts at offset 0 but does not span its ArrayBuffer', async () => {
+    // Offset 0 but shorter than the backing store: the byteLength half of the guard must catch it.
+    const backing = new ArrayBuffer(32);
+    new Uint8Array(backing).fill(9);
+    const pooled = Buffer.from(backing, 0, 8);
+    pooled.fill(5);
+    mockStat(pooled.byteLength);
+    readFileMock.mockResolvedValue(pooled as never);
+
+    const result = await getPdfFileBuffer('/fake/file.pdf', 1024);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect((result as Uint8Array).buffer).not.toBe(backing);
+    expect((result as Uint8Array).byteLength).toBe(8);
+    expect(Array.from(result as Uint8Array)).toEqual(Array.from(pooled));
+});
+
+test('file-path input copies an empty readFile buffer so pdfjs sees a plain empty input', async () => {
+    const empty = Buffer.alloc(0);
+    mockStat(0);
+    readFileMock.mockResolvedValue(empty as never);
+
+    const result = await getPdfFileBuffer('/fake/file.pdf', 1024);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect((result as Uint8Array).byteLength).toBe(0);
+    // Guard requires byteLength > 0 — empty buffers must take the copy path.
+    expect((result as Uint8Array).buffer).not.toBe(empty.buffer);
+});
+
+test('file-path input copies when the readFile buffer shares its ArrayBuffer with other data', async () => {
+    // Simulate a pooled allocation: a Buffer view at a non-zero offset of a larger ArrayBuffer.
+    const backing = new ArrayBuffer(32);
+    new Uint8Array(backing).fill(9);
+    const pooled = Buffer.from(backing, 8, 8);
+    pooled.fill(5);
+    mockStat(pooled.byteLength);
+    readFileMock.mockResolvedValue(pooled as never);
+
+    const result = await getPdfFileBuffer('/fake/file.pdf', 1024);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    // A shared backing store must NOT be handed to pdfjs (which detaches it) — expect a copy.
+    expect((result as Uint8Array).buffer).not.toBe(backing);
+    expect(Array.from(result as Uint8Array)).toEqual(Array.from(pooled));
+});

--- a/__tests__/pdf.to.png.sliding.window.test.ts
+++ b/__tests__/pdf.to.png.sliding.window.test.ts
@@ -43,12 +43,69 @@ test('should start the next page as soon as a parallel slot frees up', async () 
         };
     });
 
+    // concurrencyLimit 3 deliberately differs from SEQUENTIAL_PIPELINE_WINDOW (2) so this test
+    // proves the parallel window width really comes from the option, not the sequential constant.
     const conversionPromise = pdfToPng(new Uint8Array([1]), {
         processPagesInParallel: true,
-        concurrencyLimit: 2,
+        concurrencyLimit: 3,
         pagesToProcess: [1, 2, 3, 4, 5],
     });
 
+    await vi.waitFor(() => {
+        expect(startedPages).toEqual([1, 2, 3]);
+    });
+
+    deferredRenders.get(1)?.resolve();
+    await vi.waitFor(() => {
+        expect(startedPages).toEqual([1, 2, 3, 4]);
+    });
+
+    deferredRenders.get(2)?.resolve();
+    await vi.waitFor(() => {
+        expect(startedPages).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    deferredRenders.get(3)?.resolve();
+    deferredRenders.get(4)?.resolve();
+    deferredRenders.get(5)?.resolve();
+    const results = await conversionPromise;
+
+    expect(results.map((page) => page.pageNumber)).toEqual([1, 2, 3, 4, 5]);
+    expect(destroy).toHaveBeenCalled();
+});
+
+test('sequential mode pipelines with a window of 2 while preserving output order', async () => {
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const mockDocument = { numPages: 4, loadingTask: { destroy } } as unknown as PDFDocumentProxy;
+    vi.spyOn(pdfjsLoader, 'getPdfDocument').mockResolvedValue(mockDocument);
+
+    const startedPages: number[] = [];
+    const deferredRenders = new Map<number, { promise: Promise<void>; resolve: () => void }>();
+    for (const pageNumber of [1, 2, 3, 4]) {
+        deferredRenders.set(pageNumber, createDeferred());
+    }
+
+    vi.spyOn(pageRenderer, 'renderPdfPage').mockImplementation(async (_pdf, pageName, pageNumber) => {
+        startedPages.push(pageNumber);
+        await deferredRenders.get(pageNumber)?.promise;
+        return {
+            kind: 'content',
+            pageNumber,
+            name: pageName,
+            content: Buffer.from(String(pageNumber)),
+            path: '',
+            width: 100,
+            height: 100,
+            rotation: 0,
+        };
+    });
+
+    // Default options: processPagesInParallel is false → SEQUENTIAL_PIPELINE_WINDOW (2) applies.
+    const conversionPromise = pdfToPng(new Uint8Array([1]), {
+        pagesToProcess: [1, 2, 3, 4],
+    });
+
+    // Window of 2: page 2 starts while page 1 is still in flight, page 3 must wait.
     await vi.waitFor(() => {
         expect(startedPages).toEqual([1, 2]);
     });
@@ -65,14 +122,48 @@ test('should start the next page as soon as a parallel slot frees up', async () 
 
     deferredRenders.get(3)?.resolve();
     deferredRenders.get(4)?.resolve();
-    await vi.waitFor(() => {
-        expect(startedPages).toEqual([1, 2, 3, 4, 5]);
-    });
-
-    deferredRenders.get(5)?.resolve();
     const results = await conversionPromise;
 
-    expect(results.map((page) => page.pageNumber)).toEqual([1, 2, 3, 4, 5]);
+    expect(results.map((page) => page.pageNumber)).toEqual([1, 2, 3, 4]);
+    expect(destroy).toHaveBeenCalled();
+});
+
+test('sequential mode: a failure stops new pages after the in-flight one and throws the first error', async () => {
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const mockDocument = { numPages: 3, loadingTask: { destroy } } as unknown as PDFDocumentProxy;
+    vi.spyOn(pdfjsLoader, 'getPdfDocument').mockResolvedValue(mockDocument);
+
+    const startedPages: number[] = [];
+    const page2 = createDeferred();
+    vi.spyOn(pageRenderer, 'renderPdfPage').mockImplementation(async (_pdf, pageName, pageNumber) => {
+        startedPages.push(pageNumber);
+        if (pageNumber === 1) {
+            throw new Error('page 1 render failed');
+        }
+        await page2.promise;
+        return {
+            kind: 'content',
+            pageNumber,
+            name: pageName,
+            content: Buffer.from(String(pageNumber)),
+            path: '',
+            width: 100,
+            height: 100,
+            rotation: 0,
+        };
+    });
+
+    const conversionPromise = pdfToPng(new Uint8Array([1]), { pagesToProcess: [1, 2, 3] });
+
+    // Window of 2: pages 1 and 2 start; page 1's failure must prevent page 3 from ever starting,
+    // while the already-in-flight page 2 is allowed to finish before the promise rejects.
+    await vi.waitFor(() => {
+        expect(startedPages).toEqual([1, 2]);
+    });
+    page2.resolve();
+
+    await expect(conversionPromise).rejects.toThrow('page 1 render failed');
+    expect(startedPages).toEqual([1, 2]);
     expect(destroy).toHaveBeenCalled();
 });
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "prebuild": "npm run clean",
         "build": "tsc --pretty --project tsconfig.prod.json",
         "build:strict": "tsc --project tsconfig.strict.json",
+        "bench": "npm run build && ts-node scripts/benchmark.ts",
         "build:test": "tsc --pretty --noEmit --project tsconfig.json",
         "clean": "rimraf ./out ./test-results",
         "codemap": "ts-node scripts/generate-codemap.ts",

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,0 +1,319 @@
+/**
+ * On-demand performance benchmark for pdf-to-png-converter.
+ *
+ * Usage:
+ *   npm run bench                 # all scenarios, 5 timed iterations each (1 warmup)
+ *   BENCH_ITERATIONS=3 npm run bench
+ *   BENCH_LABEL=baseline npm run bench   # label the saved JSON results file
+ *
+ * Measures two complementary views on the same machine:
+ *  1. End-to-end wall-clock of the public `pdfToPng()` call across realistic scenarios
+ *     (sequential vs parallel, buffer vs file output, small vs large documents).
+ *  2. A per-stage breakdown (document load / getPage / render / PNG encode) obtained by
+ *     driving the internal seams (`getPdfFileBuffer`, `getPdfDocument`, `page.render()`,
+ *     `canvas.toBuffer`) directly. The breakdown intentionally re-implements the render
+ *     loop of `src/pageRenderer.ts` so each stage can be timed in isolation — it is a
+ *     measurement harness, not a second production code path. Its encode stage times the
+ *     synchronous `toBuffer('image/png')` twin of the async `encode('png')` used in
+ *     production — same native encoder and CPU cost; the async form only moves the work
+ *     off the JS thread.
+ *
+ * Runs against the compiled `out/` build (rebuilt by the npm script) so the numbers reflect
+ * exactly what the published package executes. Results are printed as a table and saved as
+ * JSON under `bench-results/` (gitignored, survives `npm run clean`) so runs can be diffed.
+ */
+import { promises as fsPromises } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
+import type { PdfToPngOptions } from '../out/index.js';
+import { pdfToPng } from '../out/index.js';
+import { PDF_TO_PNG_OPTIONS_DEFAULTS } from '../out/const.js';
+import { normalizePdfToPngOptions } from '../out/normalizePdfToPngOptions.js';
+import { getPdfFileBuffer } from '../out/pdfInput.js';
+import { getPdfDocument } from '../out/pdfjsLoader.js';
+
+const REPO_ROOT = resolve(__dirname, '..');
+const TEST_DATA = join(REPO_ROOT, 'test-data');
+// Everything bench-related lives under bench-results/ (gitignored), NOT test-results/,
+// because `npm run bench` rebuilds via `npm run build` whose clean step wipes test-results.
+const BENCH_OUTPUT_ROOT = join(REPO_ROOT, 'bench-results', 'tmp');
+const RESULTS_DIR = join(REPO_ROOT, 'bench-results');
+
+const ITERATIONS = readIntEnv('BENCH_ITERATIONS', 5, 1);
+const WARMUP_ITERATIONS = readIntEnv('BENCH_WARMUP', 1, 0);
+const LABEL = process.env.BENCH_LABEL ?? new Date().toISOString().replace(/[:.]/g, '-');
+
+interface Scenario {
+    name: string;
+    pdfFile: string;
+    options: PdfToPngOptions;
+}
+
+interface ScenarioResult {
+    name: string;
+    pages: number;
+    iterations: number;
+    medianMs: number;
+    minMs: number;
+    meanMs: number;
+    medianMsPerPage: number;
+}
+
+interface StageBreakdown {
+    pdfFile: string;
+    pages: number;
+    iterations: number;
+    docLoadMs: number;
+    getPageMs: number;
+    renderMs: number;
+    encodeMs: number;
+    totalMs: number;
+}
+
+function readIntEnv(name: string, fallback: number, min: number): number {
+    const raw = process.env[name];
+    if (raw === undefined) {
+        return fallback;
+    }
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isInteger(parsed) || parsed < min) {
+        throw new Error(`${name} must be an integer >= ${min}, received: ${raw}`);
+    }
+    return parsed;
+}
+
+function median(values: number[]): number {
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function mean(values: number[]): number {
+    return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+const SCENARIOS: Scenario[] = [
+    {
+        name: 'large_pdf (12p) → buffers, sequential',
+        pdfFile: join(TEST_DATA, 'large_pdf.pdf'),
+        options: { returnPageContent: true },
+    },
+    {
+        name: 'large_pdf (12p) → buffers, parallel(4)',
+        pdfFile: join(TEST_DATA, 'large_pdf.pdf'),
+        options: { returnPageContent: true, processPagesInParallel: true },
+    },
+    {
+        name: 'large_pdf (12p) → files, sequential',
+        pdfFile: join(TEST_DATA, 'large_pdf.pdf'),
+        options: { returnPageContent: false, outputFolder: join(BENCH_OUTPUT_ROOT, 'large-seq') },
+    },
+    {
+        name: 'large_pdf (12p) → files, parallel(4)',
+        pdfFile: join(TEST_DATA, 'large_pdf.pdf'),
+        options: { returnPageContent: false, processPagesInParallel: true, outputFolder: join(BENCH_OUTPUT_ROOT, 'large-par') },
+    },
+    {
+        name: 'sample (2p) → buffers, sequential',
+        pdfFile: join(TEST_DATA, 'sample.pdf'),
+        options: { returnPageContent: true },
+    },
+    {
+        name: 'TAMReview → buffers, sequential',
+        pdfFile: join(TEST_DATA, 'TAMReview.pdf'),
+        options: { returnPageContent: true },
+    },
+];
+
+async function runScenario(scenario: Scenario): Promise<ScenarioResult> {
+    const timings: number[] = [];
+    let pages = 0;
+
+    for (let iteration = 0; iteration < WARMUP_ITERATIONS + ITERATIONS; iteration += 1) {
+        // File-output scenarios use exclusive-create writes, so the target folder must be
+        // reset between iterations. Done outside the timed region.
+        if (scenario.options.outputFolder !== undefined) {
+            await fsPromises.rm(scenario.options.outputFolder, { recursive: true, force: true });
+        }
+
+        const start = performance.now();
+        const result = await pdfToPng(scenario.pdfFile, scenario.options);
+        const elapsed = performance.now() - start;
+
+        pages = result.length;
+        if (iteration >= WARMUP_ITERATIONS) {
+            timings.push(elapsed);
+        }
+    }
+
+    return {
+        name: scenario.name,
+        pages,
+        iterations: ITERATIONS,
+        medianMs: median(timings),
+        minMs: Math.min(...timings),
+        meanMs: mean(timings),
+        medianMsPerPage: median(timings) / pages,
+    };
+}
+
+/** Minimal structural view of pdf.js's Node canvas factory (see src/pageRenderer.ts). */
+interface BenchCanvasFactory {
+    create(
+        width: number,
+        height: number,
+    ): {
+        canvas: { toBuffer(mime: 'image/png'): Buffer } | null;
+        context: unknown;
+    };
+    destroy(canvasAndContext: unknown): void;
+}
+
+async function runStageBreakdown(pdfFile: string): Promise<StageBreakdown> {
+    const normalized = normalizePdfToPngOptions({ returnPageContent: true });
+    const stageSums = { docLoadMs: 0, getPageMs: 0, renderMs: 0, encodeMs: 0 };
+    let pages = 0;
+
+    for (let iteration = 0; iteration < WARMUP_ITERATIONS + ITERATIONS; iteration += 1) {
+        const timed = iteration >= WARMUP_ITERATIONS;
+        const buffer = await getPdfFileBuffer(pdfFile, PDF_TO_PNG_OPTIONS_DEFAULTS.maxInputBytes);
+
+        const docLoadStart = performance.now();
+        const pdfDocument: PDFDocumentProxy = await getPdfDocument(buffer, normalized);
+        if (timed) {
+            stageSums.docLoadMs += performance.now() - docLoadStart;
+        }
+
+        try {
+            pages = pdfDocument.numPages;
+            const canvasFactory = pdfDocument.canvasFactory as unknown as BenchCanvasFactory;
+
+            for (let pageNumber = 1; pageNumber <= pdfDocument.numPages; pageNumber += 1) {
+                const getPageStart = performance.now();
+                const page = await pdfDocument.getPage(pageNumber);
+                const viewport = page.getViewport({ scale: normalized.viewportScale });
+                if (timed) {
+                    stageSums.getPageMs += performance.now() - getPageStart;
+                }
+
+                const canvasAndContext = canvasFactory.create(Math.floor(viewport.width), Math.floor(viewport.height));
+                try {
+                    const renderStart = performance.now();
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore — same DOM-vs-SKRS context mismatch as src/pageRenderer.ts
+                    await page.render({ canvasContext: canvasAndContext.context, viewport, canvas: canvasAndContext.canvas }).promise;
+                    if (timed) {
+                        stageSums.renderMs += performance.now() - renderStart;
+                    }
+
+                    const encodeStart = performance.now();
+                    canvasAndContext.canvas?.toBuffer('image/png');
+                    if (timed) {
+                        stageSums.encodeMs += performance.now() - encodeStart;
+                    }
+                } finally {
+                    page.cleanup();
+                    canvasFactory.destroy(canvasAndContext);
+                }
+            }
+        } finally {
+            await pdfDocument.loadingTask.destroy();
+        }
+    }
+
+    const totalMs = stageSums.docLoadMs + stageSums.getPageMs + stageSums.renderMs + stageSums.encodeMs;
+    return {
+        pdfFile,
+        pages,
+        iterations: ITERATIONS,
+        docLoadMs: stageSums.docLoadMs / ITERATIONS,
+        getPageMs: stageSums.getPageMs / ITERATIONS,
+        renderMs: stageSums.renderMs / ITERATIONS,
+        encodeMs: stageSums.encodeMs / ITERATIONS,
+        totalMs: totalMs / ITERATIONS,
+    };
+}
+
+function formatMs(value: number): string {
+    return `${value.toFixed(1)} ms`;
+}
+
+function printScenarioTable(results: ScenarioResult[]): void {
+    console.log('\n=== End-to-end pdfToPng() ===');
+    const header = ['scenario', 'pages', 'median', 'min', 'mean', 'median/page'];
+    const rows = results.map((result) => [
+        result.name,
+        String(result.pages),
+        formatMs(result.medianMs),
+        formatMs(result.minMs),
+        formatMs(result.meanMs),
+        formatMs(result.medianMsPerPage),
+    ]);
+    const widths = header.map((title, column) => Math.max(title.length, ...rows.map((row) => row[column].length)));
+    console.log(header.map((title, column) => title.padEnd(widths[column])).join('  '));
+    for (const row of rows) {
+        console.log(row.map((cell, column) => cell.padEnd(widths[column])).join('  '));
+    }
+}
+
+function printStageBreakdown(breakdown: StageBreakdown): void {
+    console.log(`\n=== Stage breakdown: ${breakdown.pdfFile} (${breakdown.pages} pages, mean per conversion) ===`);
+    const stages: Array<[string, number]> = [
+        ['document load', breakdown.docLoadMs],
+        ['getPage+viewport', breakdown.getPageMs],
+        ['render', breakdown.renderMs],
+        ['PNG encode', breakdown.encodeMs],
+    ];
+    for (const [stage, ms] of stages) {
+        const share = breakdown.totalMs > 0 ? ((ms / breakdown.totalMs) * 100).toFixed(1) : '0.0';
+        console.log(`${stage.padEnd(18)} ${formatMs(ms).padStart(11)}  (${share}%)`);
+    }
+    console.log(`${'total'.padEnd(18)} ${formatMs(breakdown.totalMs).padStart(11)}`);
+}
+
+async function main(): Promise<void> {
+    console.log(`pdf-to-png-converter benchmark — ${ITERATIONS} iterations (+${WARMUP_ITERATIONS} warmup), label: ${LABEL}`);
+    console.log(`node ${process.version}, ${process.platform}/${process.arch}`);
+
+    const scenarioResults: ScenarioResult[] = [];
+    for (const scenario of SCENARIOS) {
+        scenarioResults.push(await runScenario(scenario));
+        console.log(`done: ${scenario.name}`);
+    }
+
+    const breakdowns: StageBreakdown[] = [];
+    for (const pdfName of ['large_pdf.pdf', 'TAMReview.pdf', 'sample.pdf']) {
+        breakdowns.push(await runStageBreakdown(join(TEST_DATA, pdfName)));
+    }
+
+    printScenarioTable(scenarioResults);
+    for (const breakdown of breakdowns) {
+        printStageBreakdown(breakdown);
+    }
+
+    await fsPromises.mkdir(RESULTS_DIR, { recursive: true });
+    const resultsPath = join(RESULTS_DIR, `${LABEL}.json`);
+    await fsPromises.writeFile(
+        resultsPath,
+        JSON.stringify(
+            {
+                label: LABEL,
+                node: process.version,
+                platform: `${process.platform}/${process.arch}`,
+                iterations: ITERATIONS,
+                warmupIterations: WARMUP_ITERATIONS,
+                scenarios: scenarioResults,
+                stageBreakdowns: breakdowns,
+            },
+            null,
+            2,
+        ),
+    );
+    console.log(`\nresults saved: ${resultsPath}`);
+}
+
+main().catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/src/const.ts
+++ b/src/const.ts
@@ -33,6 +33,14 @@ export const MAX_INPUT_BYTES = 256 * 1024 * 1024;
 export const MAX_CONCURRENCY_LIMIT = 16;
 
 /**
+ * Sliding-window size used for sequential (non-parallel) conversions. A window of 2 lets the
+ * off-thread PNG encode and disk write of page N overlap the main-thread render of page N+1,
+ * while keeping at most one extra canvas alive. Result order is preserved by the window helper;
+ * rendered pixels are unaffected.
+ */
+export const SEQUENTIAL_PIPELINE_WINDOW = 2;
+
+/**
  * Default values applied to `PdfToPngOptions` fields that are not explicitly set by the caller.
  * These are also used as the source of truth for documented defaults in JSDoc comments on the type.
  */

--- a/src/interfaces/pdf.to.png.options.ts
+++ b/src/interfaces/pdf.to.png.options.ts
@@ -110,7 +110,15 @@ export interface PdfToPngOptions {
 
     /**
      * When `true`, selected pages are rendered concurrently through a sliding-window scheduler
-     * that keeps up to `concurrencyLimit` pages active. When `false`, pages are processed one at a time in order.
+     * that keeps up to `concurrencyLimit` pages active. When `false`, pages are processed in
+     * a lightly pipelined sequence: results are always returned in page order, but the PNG
+     * encoding and disk write of page N may overlap the rendering of page N+1 (at most two
+     * pages in flight), so files may finish writing out of page order and, when a page fails,
+     * the page already in flight still completes before the returned promise rejects.
+     * Consume output via the resolved `PngPageOutput[]` (ordered) rather than directory-watch order.
+     * Peak canvas memory in this mode is up to two live canvases; for strict one-page-at-a-time
+     * processing with a single live canvas, set `processPagesInParallel: true` with
+     * `concurrencyLimit: 1` (a sliding window of exactly one page).
      * Default: `false`.
      * @since 3.7.0
      */

--- a/src/pageRenderer.ts
+++ b/src/pageRenderer.ts
@@ -9,7 +9,8 @@ import type { CanvasAndContext, InMemoryPngPageOutput, MetadataPngPageOutput, Pa
  * `create` / `destroy` slice we use. At runtime this is pdf.js's built-in Node canvas factory,
  * which is backed by `@napi-rs/canvas` (pdf.js's own optional dependency, kept as a direct
  * dependency of this package so it is always present). The produced `Canvas` therefore exposes
- * `toBuffer('image/png')`.
+ * the native Skia PNG encoders: the async `encode('png')` used by the render path and its
+ * synchronous twin `toBuffer('image/png')`.
  */
 interface CanvasFactory {
     create(width: number, height: number): CanvasAndContext;
@@ -180,7 +181,11 @@ export async function renderPdfPage(
             kind: 'content',
             pageNumber,
             name: pageName,
-            content: returnPageContent ? canvas.toBuffer('image/png') : undefined,
+            // Async encode() runs on the libuv threadpool (byte-identical to the synchronous
+            // toBuffer — same native Skia encoder) so the JS thread is free to render another
+            // page while this one compresses. The await sits inside the try block, so the
+            // finally's canvasFactory.destroy() cannot run until encoding has finished.
+            content: returnPageContent ? await canvas.encode('png') : undefined,
             path: '',
             width: canvasWidth,
             height: canvasHeight,

--- a/src/pdfInput.ts
+++ b/src/pdfInput.ts
@@ -26,6 +26,16 @@ export async function getPdfFileBuffer(
             return buffer;
         }
         if (Buffer.isBuffer(buffer)) {
+            // Zero-copy handoff. This Buffer was freshly allocated by readFile and is never
+            // exposed to the caller, so pdfjs may safely transfer (detach) its underlying
+            // ArrayBuffer — unlike the caller-owned branches below, no defensive copy is needed.
+            // readFile allocates non-pooled memory today; the full-span guard protects against
+            // any future pooled allocation whose ArrayBuffer is shared with unrelated data.
+            // Empty (or detached, byteLength 0) buffers take the copy path so pdfjs raises its
+            // clear "empty PDF" error instead of an opaque constructor TypeError.
+            if (buffer.byteLength > 0 && buffer.byteOffset === 0 && buffer.byteLength === buffer.buffer.byteLength) {
+                return new Uint8Array(buffer.buffer);
+            }
             return new Uint8Array(buffer);
         }
         throw new Error(`Unsupported buffer type: ${Object.prototype.toString.call(buffer)}`);

--- a/src/pdfToPngCore.ts
+++ b/src/pdfToPngCore.ts
@@ -1,7 +1,7 @@
 import { promises as fsPromises } from 'node:fs';
 import { parse, resolve } from 'node:path';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
-import { PDF_TO_PNG_OPTIONS_DEFAULTS } from './const.js';
+import { PDF_TO_PNG_OPTIONS_DEFAULTS, SEQUENTIAL_PIPELINE_WINDOW } from './const.js';
 import { FilesystemSink } from './filesystemSink.js';
 import type { PngPageOutput } from './interfaces/index.js';
 import type { OutputSink } from './interfaces/output.sink.js';
@@ -18,20 +18,20 @@ async function processPagesWithSlidingWindow<T>(
 ): Promise<T[]> {
     const results = new Array<T>(pageNumbers.length);
     let nextIndex = 0;
-    let firstError: unknown;
-    let hasError = false;
+    // Errors keyed by page index. Several in-flight pages can fail before the window drains;
+    // the error thrown afterwards is always the failing page with the LOWEST index, so the
+    // surfaced error is deterministic and matches what a strict page-order loop would report,
+    // regardless of which rejection happened to settle first.
+    const errorsByIndex = new Map<number, unknown>();
 
     async function runWorker(): Promise<void> {
-        while (!hasError && nextIndex < pageNumbers.length) {
+        while (errorsByIndex.size === 0 && nextIndex < pageNumbers.length) {
             const currentIndex = nextIndex;
             nextIndex += 1;
             try {
                 results[currentIndex] = await processPage(pageNumbers[currentIndex], currentIndex);
             } catch (error: unknown) {
-                if (!hasError) {
-                    firstError = error;
-                    hasError = true;
-                }
+                errorsByIndex.set(currentIndex, error);
             }
         }
     }
@@ -39,8 +39,8 @@ async function processPagesWithSlidingWindow<T>(
     const workerCount = Math.min(concurrencyLimit, pageNumbers.length);
     await Promise.allSettled(Array.from({ length: workerCount }, () => runWorker()));
 
-    if (hasError) {
-        throw firstError;
+    if (errorsByIndex.size > 0) {
+        throw errorsByIndex.get(Math.min(...errorsByIndex.keys()));
     }
 
     return results;
@@ -134,7 +134,6 @@ export async function pdfToPngCore(
         }
         const realOutputFolder: string | undefined =
             resolvedOutputFolder !== undefined ? await fsPromises.realpath(resolvedOutputFolder) : undefined;
-        const pngPageOutputs: PngPageOutput[] = [];
 
         const outputSink: OutputSink | undefined =
             resolvedOutputFolder !== undefined && realOutputFolder !== undefined
@@ -144,17 +143,15 @@ export async function pdfToPngCore(
         const processPage = async (pageNumber: number, index: number): Promise<PngPageOutput> =>
             await processAndSavePage(pdfDocument, resolvedNames[index], pageNumber, pageViewportScale, pageMode);
 
-        if (normalizedProps.processPagesInParallel === true) {
-            pngPageOutputs.push(
-                ...(await processPagesWithSlidingWindow(validPagesToProcess, normalizedProps.concurrencyLimit, processPage)),
-            );
-        } else {
-            for (const [index, pageNumber] of validPagesToProcess.entries()) {
-                pngPageOutputs.push(await processPage(pageNumber, index));
-            }
-        }
-
-        return pngPageOutputs;
+        // Sequential mode also runs through the sliding window, with a fixed window of 2: up to
+        // two pages are in flight, so page N's PNG encode (libuv threadpool) and disk write
+        // overlap page N+1's render on the JS thread. Result order and rendered pixels are
+        // identical to a strict one-at-a-time loop; side effects (disk writes) may complete out
+        // of page order, and at most one extra canvas is alive at a time.
+        const windowSize = normalizedProps.processPagesInParallel === true ? normalizedProps.concurrencyLimit : SEQUENTIAL_PIPELINE_WINDOW;
+        // Returned directly (not spread into push(...)) — spreading a huge result array into one
+        // call exceeds V8's argument-count cap and crashes on very large page counts.
+        return await processPagesWithSlidingWindow(validPagesToProcess, windowSize, processPage);
     } finally {
         await pdfDocument.loadingTask.destroy();
     }


### PR DESCRIPTION
## Summary

Makes page rendering measurably faster with zero output change — all rendered PNGs are **byte-identical** to the previous build (verified across all 37 pages of the three benchmark PDFs), no public defaults change, no new dependencies.

### What was slow (measured, not guessed)

A new committed benchmark (`npm run bench`) plus CPU profiling attributed the cost per document class:

| Document | render | PNG encode |
|---|---|---|
| `large_pdf.pdf` (12p, ~7.6 MP JPEGs) | 95.4% | 4.6% |
| `TAMReview.pdf` (23p, text-heavy) | 36.8% | **62.8%** |
| `sample.pdf` (2p) | 18.3% | **80.3%** |

For typical text documents, the synchronous `canvas.toBuffer('image/png')` dominated — and it blocks the event loop, so nothing (not even disk writes) overlapped it. `large_pdf` is the outlier: its four image pages spend ~65% of render inside pdf.js's main-thread `convertRGBToRGBA` and ~20% in its pure-JS JPEG decoder (see follow-ups).

### Changes

1. **Async off-thread PNG encode** — `canvas.toBuffer('image/png')` → `await canvas.encode('png')` (`src/pageRenderer.ts`). Same native Skia encoder, byte-identical output, but encoding now runs on the libuv threadpool and the JS thread is free to render the next page.
2. **Sequential mode pipelines** — sequential (default) conversions now run through the existing sliding-window helper with a fixed window of 2 (`SEQUENTIAL_PIPELINE_WINDOW`), so page N's encode/disk-write overlaps page N+1's render. Output order unchanged; at most one extra canvas alive.
3. **Zero-copy input handoff** — the `readFile` branch of `getPdfFileBuffer` no longer copies the whole file; the library-owned buffer is handed to pdf.js as a full-span view (guarded, with copy fallback), which pdf.js transfers without copying.
4. **Committed benchmark** — `scripts/benchmark.ts` + `npm run bench`: end-to-end scenarios (sequential/parallel × buffer/file × 3 documents) and a per-stage breakdown (load/getPage/render/encode), 5 iterations + warmup, results saved as JSON under `bench-results/` (gitignored).

### Results (median of 5, Node v22.23.1, darwin/arm64, Apple Silicon)

| Scenario | Before | After | Δ |
|---|---|---|---|
| TAMReview (23p) → buffers, sequential | 1396.3 ms | 834.8 ms | **−40.2%** |
| sample (2p) → buffers, sequential | 44.4 ms | 28.4 ms | **−36.0%** |
| large_pdf (12p) → files, parallel(4) | 12007.9 ms | 10600.7 ms | **−11.7%** |
| large_pdf (12p) → buffers, parallel(4) | 11685.8 ms | 10700.2 ms | **−8.4%** |
| large_pdf (12p) → files, sequential | 11928.0 ms | 11476.3 ms | −3.8% |
| large_pdf (12p) → buffers, sequential | 11714.4 ms | 11358.3 ms | −3.0% |

## Verification

- **Byte-identity:** all 37 output PNGs (`large_pdf`, `TAMReview`, `sample`) byte-compared before vs after — identical.
- `npm run build:test`, `npm run build:strict`, `npm run lint`, `npm run codemap` — clean.
- Full test suite: 41 files / 224 passed, 2 skipped.
- New tests: sequential window-2 pipelining + order preservation; zero-copy handoff + pooled-buffer copy fallback.
- Multi-agent adversarial review of the diff (async correctness, buffer safety, API compat, test quality): 17 raw findings, 11 confirmed after adversarial verification, all addressed:
  - **Fixed in code:** stale public JSDoc promising one-at-a-time sequential processing (HIGH); nondeterministic error selection when multiple in-flight pages fail — the sliding window now always throws the **lowest-page-index** error; `RangeError` on spread-push with very large page counts (~120k+, reachable via `returnMetadataOnly`) — result array now returned directly; zero-copy guard now routes empty/detached buffers to the copy path.
  - **Fixed in tests:** parallel window test now uses `concurrencyLimit: 3` so the option wiring is provably distinct from the sequential constant; added zero-copy tests for the offset-0/partial-span and empty-buffer branches; added a test pinning sequential failure semantics (in-flight page completes, later pages never start, first-page error surfaces).
  - **Documented (accepted behavior deltas of the minor release, see below).**

## Behavioral notes (default/sequential mode)

Pixels, result order, and API defaults are unchanged, but three side-effect-level behaviors of the default mode change with pipelining:

1. **Disk writes may complete out of page order** (e.g. a fast page 3 can land before a slow page 2). Consume output via the resolved ordered `PngPageOutput[]`, not directory-watch order.
2. **On failure, the one page already in flight still completes** (including its write) before the promise rejects — on-disk output is no longer guaranteed to be a strict page-order prefix (bounded overshoot: at most one page).
3. **Peak canvas memory is up to two live canvases** instead of one. Escape hatch for strict one-at-a-time processing: `processPagesInParallel: true` + `concurrencyLimit: 1` (a sliding window of exactly one page).

All three are documented in the `processPagesInParallel` JSDoc that ships with the package types.

## Follow-ups (out of scope, found during investigation)

- **Image-heavy pages** (`large_pdf`-class): 85% of time sits in pdf.js main-thread image work (`convertRGBToRGBA`, JS JPEG decode) — unreachable in-process. A worker-thread page-level pool is the only route to big wins there; proposal with numbers to follow separately.
- `src/outputWriter.ts` performs two identical `realpath` calls per written page (`dirname(file)` ≡ output folder due to the flat-name guard); consolidating would save a syscall per page but touches the SEC-001/002/003 guard block — left untouched deliberately.
- `package.json` contains a duplicate `"overrides"` key (pre-existing).
