### PR TITLE
perf: sequential window 3, single-realpath write path, performance docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Published to npm as `pdf-to-png-converter`. Entry: `out/index.js`, types: `out/i
 
 **Single validation boundary:** `normalizePdfToPngOptions` produces `NormalizedPdfToPngOptions`, which is consumed by `pdfToPngCore`, `getPdfDocument`, and `propsToPdfDocInitParams`. No downstream module re-applies `??` defaults — all defaulting happens in the normalizer.
 
-**Concurrency:** all conversions run through a sliding window (`processPagesWithSlidingWindow` in `src/pdfToPngCore.ts`). Parallel mode (`processPagesInParallel: true`) uses a window of `concurrencyLimit` (default 4); sequential (default) uses a fixed window of 2 (`SEQUENTIAL_PIPELINE_WINDOW`) so the off-thread PNG encode (async `canvas.encode('png')` on the libuv threadpool) and disk write of page N overlap the render of page N+1. Output order is preserved in both modes.
+**Concurrency:** all conversions run through a sliding window (`processPagesWithSlidingWindow` in `src/pdfToPngCore.ts`). Parallel mode (`processPagesInParallel: true`) uses a window of `concurrencyLimit` (default 4); sequential (default) uses a fixed window of 3 (`SEQUENTIAL_PIPELINE_WINDOW`, sized by paired A/B measurement — encode ≈ 2× render on text docs; the bump is worth ~2–5%) so the off-thread PNG encodes (async `canvas.encode('png')` on the libuv threadpool) and disk writes of finished pages overlap the next page's render. Output order is preserved in both modes.
 
 **`outputFolder` + `returnPageContent` + `returnMetadataOnly` interaction:**
 

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.1.1"
   },
-  "sourceHash": "c08a02effbdea3abf2652edbd2f60447106d1c982a09ae07c2bad46b8bbcf486",
+  "sourceHash": "e1652ed20183c632529a999d894636195eb21b2ba77f476fda7275e9ad9adccf",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -237,35 +237,35 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "SEQUENTIAL_PIPELINE_WINDOW",
           "kind": "variable",
-          "line": 41,
+          "line": 45,
           "exported": true,
-          "signature": "export const SEQUENTIAL_PIPELINE_WINDOW = 2"
+          "signature": "export const SEQUENTIAL_PIPELINE_WINDOW = 3"
         },
         {
           "name": "PDF_TO_PNG_OPTIONS_DEFAULTS",
           "kind": "variable",
-          "line": 47,
+          "line": 51,
           "exported": true,
           "signature": "export const PDF_TO_PNG_OPTIONS_DEFAULTS = { viewportScale: 1, disableFontFace: true, useSystemFonts: false, enableXfa: true, outputFileMask: 'buffer', pdfFilePassword: undefined, concurrencyLimit: 4,…"
         },
         {
           "name": "CMAP_RELATIVE_URL",
           "kind": "variable",
-          "line": 66,
+          "line": 70,
           "exported": true,
           "signature": "export const CMAP_RELATIVE_URL = './node_modules/pdfjs-dist/cmaps/'"
         },
         {
           "name": "STANDARD_FONTS_RELATIVE_URL",
           "kind": "variable",
-          "line": 67,
+          "line": 71,
           "exported": true,
           "signature": "export const STANDARD_FONTS_RELATIVE_URL = './node_modules/pdfjs-dist/standard_fonts/'"
         },
         {
           "name": "DOCUMENT_INIT_PARAMS_DEFAULTS",
           "kind": "variable",
-          "line": 79,
+          "line": 83,
           "exported": true,
           "signature": "export const DOCUMENT_INIT_PARAMS_DEFAULTS: DocumentInitParameters = { cMapUrl: CMAP_RELATIVE_URL, cMapPacked: true, standardFontDataUrl: STANDARD_FONTS_RELATIVE_URL, }"
         }
@@ -586,7 +586,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "savePNGfile",
           "kind": "function",
-          "line": 29,
+          "line": 33,
           "exported": true,
           "signature": "export async function savePNGfile(name: string, content: Buffer, resolvedOutputFolder: string, realOutputFolder: string): Promise<string>"
         }
@@ -601,7 +601,6 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "from": "node:path",
           "names": [
-            "dirname",
             "isAbsolute",
             "join",
             "relative",

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -10,7 +10,7 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
     "name": "pdf-to-png-converter",
     "version": "4.1.1"
   },
-  "sourceHash": "e1652ed20183c632529a999d894636195eb21b2ba77f476fda7275e9ad9adccf",
+  "sourceHash": "f166bb5c78ea168131d1fc4d5ead03212accbe88c703725e75470947d6a35d3e",
   "entrypoints": [
     "src/index.ts"
   ],
@@ -237,35 +237,35 @@ Verified by `npm run codemap:check` (CI). Do not hand-edit.
         {
           "name": "SEQUENTIAL_PIPELINE_WINDOW",
           "kind": "variable",
-          "line": 45,
+          "line": 46,
           "exported": true,
           "signature": "export const SEQUENTIAL_PIPELINE_WINDOW = 3"
         },
         {
           "name": "PDF_TO_PNG_OPTIONS_DEFAULTS",
           "kind": "variable",
-          "line": 51,
+          "line": 52,
           "exported": true,
           "signature": "export const PDF_TO_PNG_OPTIONS_DEFAULTS = { viewportScale: 1, disableFontFace: true, useSystemFonts: false, enableXfa: true, outputFileMask: 'buffer', pdfFilePassword: undefined, concurrencyLimit: 4,…"
         },
         {
           "name": "CMAP_RELATIVE_URL",
           "kind": "variable",
-          "line": 70,
+          "line": 71,
           "exported": true,
           "signature": "export const CMAP_RELATIVE_URL = './node_modules/pdfjs-dist/cmaps/'"
         },
         {
           "name": "STANDARD_FONTS_RELATIVE_URL",
           "kind": "variable",
-          "line": 71,
+          "line": 72,
           "exported": true,
           "signature": "export const STANDARD_FONTS_RELATIVE_URL = './node_modules/pdfjs-dist/standard_fonts/'"
         },
         {
           "name": "DOCUMENT_INIT_PARAMS_DEFAULTS",
           "kind": "variable",
-          "line": 83,
+          "line": 84,
           "exported": true,
           "signature": "export const DOCUMENT_INIT_PARAMS_DEFAULTS: DocumentInitParameters = { cMapUrl: CMAP_RELATIVE_URL, cMapPacked: true, standardFontDataUrl: STANDARD_FONTS_RELATIVE_URL, }"
         }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A high-performance Node.js library for converting PDF files and buffers to PNG i
 - [CLI Usage](#cli-usage)
 - [API Reference](#api-reference)
 - [Examples](#examples)
+- [Performance Notes](#performance-notes)
 - [Output Format](#output-format)
 - [Migration Guide](#migration-guide)
 - [Project Links](#project-links)
@@ -297,6 +298,14 @@ pages.forEach((page) => {
 ```
 
 This is significantly faster than full rendering and useful for checking page counts, dimensions, or orientation before deciding how to process a document.
+
+---
+
+## Performance Notes
+
+- **Pipelined processing.** PNG encoding runs on the libuv threadpool and overlaps page rendering, so files may finish writing out of page order even in default (non-parallel) mode. Always consume results via the resolved, page-ordered array rather than directory-watch order.
+- **Threadpool sizing.** PNG encodes and disk writes share Node's libuv threadpool (4 threads by default). For parallel file-output workloads on many-core machines, raising it can help: `UV_THREADPOOL_SIZE=8 node app.js`.
+- **Strict serial processing.** If you need exactly one page in flight at a time (minimal memory, strict on-disk ordering), use `processPagesInParallel: true` with `concurrencyLimit: 1` — a sliding window of exactly one page.
 
 ---
 

--- a/__tests__/coverage.test.ts
+++ b/__tests__/coverage.test.ts
@@ -245,43 +245,6 @@ describe('pdfToPng', () => {
         expect(mockCanvasFactory.destroy).toHaveBeenCalledWith(created);
     });
 
-    it('should throw when outputFolder directory resolves outside outputFolder via symlink (symlink escape on dirname)', async () => {
-        // Simulates a symlink swap: the filename is safe-looking but realpath(dirname(file))
-        // resolves to a path outside realOutputFolder — L458 in savePNGfile.
-        const mockCanvas = { encode: vi.fn().mockResolvedValue(Buffer.alloc(0)) };
-        const mockCanvasFactory = {
-            create: vi.fn().mockReturnValue({ canvas: mockCanvas, context: {} }),
-            destroy: vi.fn(),
-        };
-        const mockPage = {
-            getViewport: vi.fn().mockReturnValue({ width: 10, height: 10 }),
-            render: vi.fn().mockReturnValue({ promise: Promise.resolve() }),
-            rotate: 0,
-            cleanup: vi.fn(),
-        };
-        const mockDocument = {
-            numPages: 1,
-            getPage: vi.fn().mockResolvedValue(mockPage),
-            cleanup: vi.fn(),
-            loadingTask: { destroy: vi.fn().mockResolvedValue(undefined) },
-            canvasFactory: mockCanvasFactory,
-        };
-
-        (fsPromises.readFile as Mock).mockResolvedValueOnce(new ArrayBuffer(8));
-        (getDocument as Mock).mockReturnValueOnce({
-            promise: Promise.resolve(mockDocument),
-        });
-        (fsPromises.mkdir as Mock).mockResolvedValueOnce(undefined);
-        // 1st realpath: resolvedOutputFolder in pdfToPng → establishes realOutputFolder
-        // 2nd realpath: dirname(resolvedFilePath) in savePNGfile → escapes (simulates symlink)
-        (fsPromises.realpath as Mock).mockResolvedValueOnce('/safe/output').mockResolvedValueOnce('/evil');
-
-        await expect(pdfToPng('/path/to/test.pdf', { outputFolder: 'test-output' })).rejects.toThrow(
-            'Output file name escapes the output folder',
-        );
-        expect(fsPromises.open).not.toHaveBeenCalled();
-    });
-
     it('should throw when content is undefined at write time (defensive guard)', async () => {
         // Simulates canvas.encode() resolving to undefined (e.g. broken canvas implementation).
         // Guards L463: the savePNGfile defensive check that content must not be undefined.
@@ -309,9 +272,9 @@ describe('pdfToPng', () => {
             promise: Promise.resolve(mockDocument),
         });
         (fsPromises.mkdir as Mock).mockResolvedValueOnce(undefined);
-        // Both realpath calls return the same safe path so the symlink check (L457) passes;
-        // L463 fires before the TOCTOU re-check (L474) is reached.
-        (fsPromises.realpath as Mock).mockResolvedValueOnce('/safe/output').mockResolvedValueOnce('/safe/output');
+        // Only the initial realpath in pdfToPngCore is consumed — the undefined-content guard
+        // fires in the page orchestrator before savePNGfile is ever called.
+        (fsPromises.realpath as Mock).mockResolvedValueOnce('/safe/output');
 
         await expect(pdfToPng('/path/to/test.pdf', { outputFolder: 'test-output' })).rejects.toThrow('Cannot write PNG file');
         expect(fsPromises.open).not.toHaveBeenCalled();
@@ -344,13 +307,12 @@ describe('pdfToPng', () => {
             promise: Promise.resolve(mockDocument),
         });
         (fsPromises.mkdir as Mock).mockResolvedValueOnce(undefined);
-        // 1st realpath: resolvedOutputFolder in pdfToPng (cached as realOutputFolder) — passes
-        // 2nd realpath: dirname(resolvedFilePath) in savePNGfile (symlink containment check) — passes
-        // 3rd realpath: resolvedOutputFolder in savePNGfile (final TOCTOU re-check) — differs → throws
-        (fsPromises.realpath as Mock)
-            .mockResolvedValueOnce('/safe/output')
-            .mockResolvedValueOnce('/safe/output')
-            .mockResolvedValueOnce('/swapped/evil');
+        // 1st realpath: resolvedOutputFolder in pdfToPngCore (cached as realOutputFolder) — passes
+        // 2nd realpath: resolvedOutputFolder in savePNGfile (pre-open re-check) — differs → throws.
+        // This single equality re-check also subsumes the old dirname containment check: with
+        // flat filenames the file's directory IS the output folder, and any symlink swap makes
+        // the fresh realpath differ from the cached one.
+        (fsPromises.realpath as Mock).mockResolvedValueOnce('/safe/output').mockResolvedValueOnce('/swapped/evil');
 
         await expect(pdfToPng('/path/to/test.pdf', { outputFolder: 'test-output' })).rejects.toThrow(
             'Output folder was modified during write',

--- a/__tests__/path.traversal.test.ts
+++ b/__tests__/path.traversal.test.ts
@@ -92,6 +92,12 @@ test.runIf(isWindows)('savePNGfile should reject "\\" on Windows before any I/O'
     );
 });
 
+test('savePNGfile should reject "." before any I/O (would collapse to the output folder itself)', async () => {
+    await expect(savePNGfile('.', Buffer.alloc(0), '/tmp/does-not-matter', '/tmp/does-not-matter')).rejects.toThrow(
+        'Output file name must be a plain filename',
+    );
+});
+
 test('pdfToPng should reject outputFileMaskFunc returning a subdirectory filename', async () => {
     await fsPromises.rm(resolve(outputFolder), { recursive: true, force: true });
     await expect(

--- a/__tests__/pdf.to.png.sliding.window.test.ts
+++ b/__tests__/pdf.to.png.sliding.window.test.ts
@@ -43,14 +43,74 @@ test('should start the next page as soon as a parallel slot frees up', async () 
         };
     });
 
-    // concurrencyLimit 3 deliberately differs from SEQUENTIAL_PIPELINE_WINDOW (2) so this test
-    // proves the parallel window width really comes from the option, not the sequential constant.
+    // concurrencyLimit 2 deliberately differs from SEQUENTIAL_PIPELINE_WINDOW (3) so this test
+    // proves the parallel window width really comes from the option, not the sequential constant
+    // — including narrowing below it.
     const conversionPromise = pdfToPng(new Uint8Array([1]), {
         processPagesInParallel: true,
-        concurrencyLimit: 3,
+        concurrencyLimit: 2,
         pagesToProcess: [1, 2, 3, 4, 5],
     });
 
+    await vi.waitFor(() => {
+        expect(startedPages).toEqual([1, 2]);
+    });
+
+    deferredRenders.get(1)?.resolve();
+    await vi.waitFor(() => {
+        expect(startedPages).toEqual([1, 2, 3]);
+    });
+
+    deferredRenders.get(2)?.resolve();
+    await vi.waitFor(() => {
+        expect(startedPages).toEqual([1, 2, 3, 4]);
+    });
+
+    deferredRenders.get(3)?.resolve();
+    deferredRenders.get(4)?.resolve();
+    await vi.waitFor(() => {
+        expect(startedPages).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    deferredRenders.get(5)?.resolve();
+    const results = await conversionPromise;
+
+    expect(results.map((page) => page.pageNumber)).toEqual([1, 2, 3, 4, 5]);
+    expect(destroy).toHaveBeenCalled();
+});
+
+test('sequential mode pipelines with a window of 3 while preserving output order', async () => {
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const mockDocument = { numPages: 5, loadingTask: { destroy } } as unknown as PDFDocumentProxy;
+    vi.spyOn(pdfjsLoader, 'getPdfDocument').mockResolvedValue(mockDocument);
+
+    const startedPages: number[] = [];
+    const deferredRenders = new Map<number, { promise: Promise<void>; resolve: () => void }>();
+    for (const pageNumber of [1, 2, 3, 4, 5]) {
+        deferredRenders.set(pageNumber, createDeferred());
+    }
+
+    vi.spyOn(pageRenderer, 'renderPdfPage').mockImplementation(async (_pdf, pageName, pageNumber) => {
+        startedPages.push(pageNumber);
+        await deferredRenders.get(pageNumber)?.promise;
+        return {
+            kind: 'content',
+            pageNumber,
+            name: pageName,
+            content: Buffer.from(String(pageNumber)),
+            path: '',
+            width: 100,
+            height: 100,
+            rotation: 0,
+        };
+    });
+
+    // Default options: processPagesInParallel is false → SEQUENTIAL_PIPELINE_WINDOW (3) applies.
+    const conversionPromise = pdfToPng(new Uint8Array([1]), {
+        pagesToProcess: [1, 2, 3, 4, 5],
+    });
+
+    // Window of 3: pages 2 and 3 start while page 1 is still in flight, page 4 must wait.
     await vi.waitFor(() => {
         expect(startedPages).toEqual([1, 2, 3]);
     });
@@ -74,19 +134,21 @@ test('should start the next page as soon as a parallel slot frees up', async () 
     expect(destroy).toHaveBeenCalled();
 });
 
-test('sequential mode pipelines with a window of 2 while preserving output order', async () => {
+test('sequential mode: a failure stops new pages after the in-flight ones and throws the first error', async () => {
     const destroy = vi.fn().mockResolvedValue(undefined);
-    const mockDocument = { numPages: 4, loadingTask: { destroy } } as unknown as PDFDocumentProxy;
+    const mockDocument = { numPages: 5, loadingTask: { destroy } } as unknown as PDFDocumentProxy;
     vi.spyOn(pdfjsLoader, 'getPdfDocument').mockResolvedValue(mockDocument);
 
     const startedPages: number[] = [];
     const deferredRenders = new Map<number, { promise: Promise<void>; resolve: () => void }>();
-    for (const pageNumber of [1, 2, 3, 4]) {
+    for (const pageNumber of [2, 3]) {
         deferredRenders.set(pageNumber, createDeferred());
     }
-
     vi.spyOn(pageRenderer, 'renderPdfPage').mockImplementation(async (_pdf, pageName, pageNumber) => {
         startedPages.push(pageNumber);
+        if (pageNumber === 1) {
+            throw new Error('page 1 render failed');
+        }
         await deferredRenders.get(pageNumber)?.promise;
         return {
             kind: 'content',
@@ -100,70 +162,18 @@ test('sequential mode pipelines with a window of 2 while preserving output order
         };
     });
 
-    // Default options: processPagesInParallel is false → SEQUENTIAL_PIPELINE_WINDOW (2) applies.
-    const conversionPromise = pdfToPng(new Uint8Array([1]), {
-        pagesToProcess: [1, 2, 3, 4],
-    });
+    const conversionPromise = pdfToPng(new Uint8Array([1]), { pagesToProcess: [1, 2, 3, 4, 5] });
 
-    // Window of 2: page 2 starts while page 1 is still in flight, page 3 must wait.
-    await vi.waitFor(() => {
-        expect(startedPages).toEqual([1, 2]);
-    });
-
-    deferredRenders.get(1)?.resolve();
+    // Window of 3: pages 1-3 start; page 1's failure must prevent pages 4 and 5 from ever
+    // starting, while the already-in-flight pages 2 and 3 finish before the promise rejects.
     await vi.waitFor(() => {
         expect(startedPages).toEqual([1, 2, 3]);
     });
-
     deferredRenders.get(2)?.resolve();
-    await vi.waitFor(() => {
-        expect(startedPages).toEqual([1, 2, 3, 4]);
-    });
-
     deferredRenders.get(3)?.resolve();
-    deferredRenders.get(4)?.resolve();
-    const results = await conversionPromise;
-
-    expect(results.map((page) => page.pageNumber)).toEqual([1, 2, 3, 4]);
-    expect(destroy).toHaveBeenCalled();
-});
-
-test('sequential mode: a failure stops new pages after the in-flight one and throws the first error', async () => {
-    const destroy = vi.fn().mockResolvedValue(undefined);
-    const mockDocument = { numPages: 3, loadingTask: { destroy } } as unknown as PDFDocumentProxy;
-    vi.spyOn(pdfjsLoader, 'getPdfDocument').mockResolvedValue(mockDocument);
-
-    const startedPages: number[] = [];
-    const page2 = createDeferred();
-    vi.spyOn(pageRenderer, 'renderPdfPage').mockImplementation(async (_pdf, pageName, pageNumber) => {
-        startedPages.push(pageNumber);
-        if (pageNumber === 1) {
-            throw new Error('page 1 render failed');
-        }
-        await page2.promise;
-        return {
-            kind: 'content',
-            pageNumber,
-            name: pageName,
-            content: Buffer.from(String(pageNumber)),
-            path: '',
-            width: 100,
-            height: 100,
-            rotation: 0,
-        };
-    });
-
-    const conversionPromise = pdfToPng(new Uint8Array([1]), { pagesToProcess: [1, 2, 3] });
-
-    // Window of 2: pages 1 and 2 start; page 1's failure must prevent page 3 from ever starting,
-    // while the already-in-flight page 2 is allowed to finish before the promise rejects.
-    await vi.waitFor(() => {
-        expect(startedPages).toEqual([1, 2]);
-    });
-    page2.resolve();
 
     await expect(conversionPromise).rejects.toThrow('page 1 render failed');
-    expect(startedPages).toEqual([1, 2]);
+    expect(startedPages).toEqual([1, 2, 3]);
     expect(destroy).toHaveBeenCalled();
 });
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -33,12 +33,17 @@ export const MAX_INPUT_BYTES = 256 * 1024 * 1024;
 export const MAX_CONCURRENCY_LIMIT = 16;
 
 /**
- * Sliding-window size used for sequential (non-parallel) conversions. A window of 2 lets the
- * off-thread PNG encode and disk write of page N overlap the main-thread render of page N+1,
- * while keeping at most one extra canvas alive. Result order is preserved by the window helper;
- * rendered pixels are unaffected.
+ * Sliding-window size used for sequential (non-parallel) conversions. The window lets the
+ * off-thread PNG encode and disk write of finished pages overlap the main-thread render of the
+ * next page. Result order is preserved by the window helper; rendered pixels are unaffected.
+ *
+ * Sized 3 by paired A/B measurement: on text-heavy documents PNG encode costs ~2× render, and a
+ * second in-flight encode recovers a small but consistent margin (TAMReview.pdf: −2…−5% median
+ * end-to-end vs window 2 in interleaved trials, faster in 3 of 4 pairs; larger single-run
+ * differences did not replicate under controlled re-measurement). Window 4 measured within
+ * noise of 3. Peak cost: up to three live canvases.
  */
-export const SEQUENTIAL_PIPELINE_WINDOW = 2;
+export const SEQUENTIAL_PIPELINE_WINDOW = 3;
 
 /**
  * Default values applied to `PdfToPngOptions` fields that are not explicitly set by the caller.

--- a/src/interfaces/pdf.to.png.options.ts
+++ b/src/interfaces/pdf.to.png.options.ts
@@ -112,11 +112,11 @@ export interface PdfToPngOptions {
      * When `true`, selected pages are rendered concurrently through a sliding-window scheduler
      * that keeps up to `concurrencyLimit` pages active. When `false`, pages are processed in
      * a lightly pipelined sequence: results are always returned in page order, but the PNG
-     * encoding and disk write of page N may overlap the rendering of page N+1 (at most two
-     * pages in flight), so files may finish writing out of page order and, when a page fails,
-     * the page already in flight still completes before the returned promise rejects.
+     * encoding and disk writes of finished pages may overlap the rendering of the next page
+     * (at most three pages in flight), so files may finish writing out of page order and, when
+     * a page fails, pages already in flight still complete before the returned promise rejects.
      * Consume output via the resolved `PngPageOutput[]` (ordered) rather than directory-watch order.
-     * Peak canvas memory in this mode is up to two live canvases; for strict one-page-at-a-time
+     * Peak canvas memory in this mode is up to three live canvases; for strict one-page-at-a-time
      * processing with a single live canvas, set `processPagesInParallel: true` with
      * `concurrencyLimit: 1` (a sliding window of exactly one page).
      * Default: `false`.

--- a/src/outputWriter.ts
+++ b/src/outputWriter.ts
@@ -1,5 +1,5 @@
 import { promises as fsPromises } from 'node:fs';
-import { dirname, isAbsolute, join, relative, sep } from 'node:path';
+import { isAbsolute, join, relative, sep } from 'node:path';
 
 // Reject only characters the host OS treats as path separators. On POSIX, "\" is a valid
 // filename character (e.g. PDFs named `foo\bar.pdf` produce a default mask of `foo\bar`) so
@@ -22,7 +22,11 @@ function isEscapingRelativePath(rel: string): boolean {
  * attacker with write access to the output folder could otherwise swap a sub-directory for a
  * symlink between the realpath check and the `open()` call). The `'wx'` flag additionally
  * prevents overwriting an existing target and blocks following a pre-existing symlink at the
- * target filename on POSIX systems. Callers should clear the output folder before re-running
+ * target filename on POSIX systems. Because the filename is flat, the file's directory IS the
+ * output folder itself, so a single fresh `realpath` of the output folder immediately before
+ * `open()` — compared for exact equality with the value captured at conversion start — detects
+ * any symlink swap or rename of the folder or its ancestors in one syscall (equality is strictly
+ * stronger than a containment check). Callers should clear the output folder before re-running
  * the same conversion if they expect to reuse the same output names. The input object is not
  * mutated; callers receive the resolved path from the return value.
  */
@@ -35,13 +39,16 @@ export async function savePNGfile(name: string, content: Buffer, resolvedOutputF
         throw new Error(`Output file name escapes the output folder: ${name}`);
     }
 
-    const resolvedFilePath = join(resolvedOutputFolder, name);
-    if (isEscapingRelativePath(relative(resolvedOutputFolder, resolvedFilePath))) {
-        throw new Error(`Output file name escapes the output folder: ${name}`);
+    // '.' collapses to the output folder itself under join() (bypassing the escape checks below,
+    // since relative() yields ''), and would surface as a raw EEXIST/EISDIR from open() that
+    // leaks the absolute folder path. '..' needs no twin guard: it resolves to the PARENT folder,
+    // which the escaping-relative check below already rejects cleanly.
+    if (name === '.') {
+        throw new Error(`Output file name must be a plain filename, received: ${name}`);
     }
 
-    const realFileDir = await fsPromises.realpath(dirname(resolvedFilePath));
-    if (isEscapingRelativePath(relative(realOutputFolder, realFileDir))) {
+    const resolvedFilePath = join(resolvedOutputFolder, name);
+    if (isEscapingRelativePath(relative(resolvedOutputFolder, resolvedFilePath))) {
         throw new Error(`Output file name escapes the output folder: ${name}`);
     }
 

--- a/src/pdfToPngCore.ts
+++ b/src/pdfToPngCore.ts
@@ -143,11 +143,11 @@ export async function pdfToPngCore(
         const processPage = async (pageNumber: number, index: number): Promise<PngPageOutput> =>
             await processAndSavePage(pdfDocument, resolvedNames[index], pageNumber, pageViewportScale, pageMode);
 
-        // Sequential mode also runs through the sliding window, with a fixed window of 2: up to
-        // two pages are in flight, so page N's PNG encode (libuv threadpool) and disk write
-        // overlap page N+1's render on the JS thread. Result order and rendered pixels are
-        // identical to a strict one-at-a-time loop; side effects (disk writes) may complete out
-        // of page order, and at most one extra canvas is alive at a time.
+        // Sequential mode also runs through the sliding window, with a fixed window of
+        // SEQUENTIAL_PIPELINE_WINDOW (3): the PNG encodes (libuv threadpool) and disk writes of
+        // finished pages overlap the next page's render on the JS thread. Result order and
+        // rendered pixels are identical to a strict one-at-a-time loop; side effects (disk
+        // writes) may complete out of page order, and up to three canvases are alive at a time.
         const windowSize = normalizedProps.processPagesInParallel === true ? normalizedProps.concurrencyLimit : SEQUENTIAL_PIPELINE_WINDOW;
         // Returned directly (not spread into push(...)) — spreading a huge result array into one
         // call exceeds V8's argument-count cap and crashes on very large page counts.


### PR DESCRIPTION
## Summary

Follow-up to #222 — the small-item half of the performance roadmap. Output stays **byte-identical** (verified across all 37 pages of the three benchmark PDFs), no public defaults change, no new dependencies.

### Changes

1. **Sequential pipeline window 2 → 3** (`SEQUENTIAL_PIPELINE_WINDOW`). On text-heavy documents PNG encode costs ~2× render, so one in-flight encode left the pipeline encode-bound. Honest effect size, from interleaved paired A/B trials on an otherwise idle machine: **−2…−5% median end-to-end on TAMReview.pdf, faster in 3 of 4 pairs** (window-2 median 844 ms → window-3 median 834 ms; best clean full runs 835 ms → 789 ms). A larger single-run difference (−21%) observed during development **did not replicate** under controlled re-measurement and was a thermal artifact — it is deliberately not claimed. Window 4 measured within noise of 3. Peak canvas memory rises to at most three live canvases (JSDoc updated; the `processPagesInParallel: true` + `concurrencyLimit: 1` strict-serial escape hatch is unchanged).
2. **Single `realpath` per written page** (was two). The flat-filename guarantee makes `dirname(file)` string-identical to the output folder, so the containment check duplicated the pre-open equality re-check — which is strictly stronger (any symlink swap or ancestor rename makes the fresh realpath differ from the value cached at conversion start). An **adversarial security review** (scoped to the SEC-001/002/003 threat model: symlink swaps, TOCTOU windows, Windows separators, caller bypasses, error leakage) returned **SAFE** — the surviving check occupies the same position immediately before `open('wx')`, so the race window is unchanged. The review also surfaced an edge the removed check had caught by accident: `outputFileMaskFunc: () => '.'` collapses to the output folder itself and produced a raw `EEXIST` leaking the absolute path — now rejected explicitly with a clean error before any I/O (new test).
3. **README “Performance Notes” section**: out-of-order write completion + ordered-array consumption, `UV_THREADPOOL_SIZE` tuning for parallel file output, and the strict-serial escape hatch.

### Not included (tracked separately)

The worker-thread page pool for image-heavy PDFs (#223) — compat spike passed (byte-identical rendering inside `worker_threads`, 4 concurrent workers rendered large_pdf's four ~2.6 s pages in 3.2 s total, ~3.4×); implementation follows as its own PR.

## Verification

- Byte-identity: all 37 output PNGs identical before vs after.
- Full gate green: `build:test`, `build:strict`, `lint`, `codemap:check`, `format:check`, license, full suite with coverage (98.45% statements, 230 passed / 2 skipped).
- Security: dedicated adversarial review of the write-path change (verdict SAFE; its one LOW finding fixed in this PR).
- Tests updated: window-3 pipelining/order/failure-semantics tests; parallel window test pinned at `concurrencyLimit: 2` (provably distinct from the sequential constant); new `'.'` rejection test.
