### PR TITLE
test: gate releases on an empty [Unreleased], and fix P4 under npm 12

### DIFF
--- a/scripts/release-precheck.ts
+++ b/scripts/release-precheck.ts
@@ -150,10 +150,14 @@ function checkUnreleasedIsEmpty(failures: string[]): void {
     const stranded = body
         .split('\n')
         .map((line) => line.trim())
-        .filter((line) => line.length > 0);
+        // Sub-headings are scaffolding, not content: an `[Unreleased]` left holding an empty
+        // "### Changed" ships nothing and must not block the release. Everything else counts —
+        // narrowing this to bullet lines would let stranded prose through, and prose under
+        // `[Unreleased]` describes shipped behaviour just as much as a bullet does.
+        .filter((line) => line.length > 0 && !line.startsWith('#'));
     if (stranded.length > 0) {
         failures.push(
-            `P5 CHANGELOG.md still has ${stranded.length} line(s) under "## [Unreleased]" — move them into the version section being released, or they ship undocumented`,
+            `P5 CHANGELOG.md still has ${stranded.length} entry line(s) under "## [Unreleased]" — move them into the version section being released, or they ship undocumented`,
         );
         return;
     }

--- a/scripts/release-precheck.ts
+++ b/scripts/release-precheck.ts
@@ -89,12 +89,21 @@ function checkTarballContents(failures: string[]): void {
     let files: string[];
     try {
         const out = runNpm(['pack', '--dry-run', '--ignore-scripts', '--json']);
-        const start = out.indexOf('[');
+        // npm <= 11 prints a JSON ARRAY of pack results; npm >= 12 prints an OBJECT keyed by
+        // package name. Anchoring on the first "[" parsed the nested "files" array and then
+        // choked on the trailing keys, so P4 reported "could not inspect the tarball" and blocked
+        // the release. Accept both shapes — publish.yml currently pins npm@11.13.0, so this is
+        // latent there but active for anyone running the precheck locally on npm 12.
+        const start = out.search(/[[{]/);
         if (start === -1) {
-            throw new Error('no JSON array in "npm pack" output');
+            throw new Error('no JSON in "npm pack" output');
         }
-        const result = JSON.parse(out.slice(start)) as PackResult[];
-        files = result[0].files.map((file) => file.path.replace(/\\/g, '/'));
+        const parsed: unknown = JSON.parse(out.slice(start));
+        const result = (Array.isArray(parsed) ? parsed[0] : Object.values(parsed as Record<string, unknown>)[0]) as PackResult | undefined;
+        if (result?.files === undefined) {
+            throw new Error('"npm pack" output has no file list');
+        }
+        files = result.files.map((file) => file.path.replace(/\\/g, '/'));
     } catch (err) {
         failures.push(`P4 could not inspect the tarball: ${err instanceof Error ? err.message : String(err)}`);
         return;
@@ -118,6 +127,39 @@ function checkTarballContents(failures: string[]): void {
     }
 }
 
+// P5 — `[Unreleased]` must be empty at publish time.
+//
+// P3 only asks whether a section for THIS version exists; it says nothing about entries still
+// sitting under `[Unreleased]`. Those entries are in the working tree, so they are in the tarball
+// — the release would ship code its own changelog calls unreleased. This is not hypothetical: it
+// happened while 4.2.0 sat version-bumped but unpublished and later work landed on top of it, and
+// P1-P4 all passed. The documented flow (CONTRIBUTING "Cutting a release", step 2) is to move
+// `[Unreleased]` into the new version section, so a non-empty one at this point means that step
+// was skipped.
+function checkUnreleasedIsEmpty(failures: string[]): void {
+    const changelog = readFileSync(join(REPO_ROOT, 'CHANGELOG.md'), 'utf-8');
+    const start = changelog.search(/^##\s*\[Unreleased\]/m);
+    if (start === -1) {
+        // No `[Unreleased]` heading at all is fine — nothing can be stranded under it.
+        console.log('  P5 [Unreleased] is empty:  OK (no [Unreleased] section)');
+        return;
+    }
+    const rest = changelog.slice(start);
+    const nextHeading = rest.slice(1).search(/^##\s/m);
+    const body = nextHeading === -1 ? rest.replace(/^##.*$/m, '') : rest.slice(0, nextHeading + 1).replace(/^##.*$/m, '');
+    const stranded = body
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    if (stranded.length > 0) {
+        failures.push(
+            `P5 CHANGELOG.md still has ${stranded.length} line(s) under "## [Unreleased]" — move them into the version section being released, or they ship undocumented`,
+        );
+        return;
+    }
+    console.log('  P5 [Unreleased] is empty:  OK');
+}
+
 function main(): void {
     const { name, version } = readManifest();
     console.log(`release:precheck for ${name}@${version}`);
@@ -126,6 +168,7 @@ function main(): void {
     checkNotAlreadyPublished(name, version, failures);
     checkChangelogEntry(version, failures);
     checkTarballContents(failures);
+    checkUnreleasedIsEmpty(failures);
     if (failures.length > 0) {
         console.error('\nrelease:precheck FAILED:');
         for (const failure of failures) {


### PR DESCRIPTION
Two changes to `release:precheck`, both found by running the gate rather than reasoning about it.

## P5 — `[Unreleased]` must be empty at publish time

P3 only asks whether a section for the version being published exists. It says nothing about entries still sitting under `[Unreleased]` — and those entries are in the working tree, so they are in the tarball. The release ships code its own changelog calls unreleased.

This is not hypothetical. 4.2.0 sat version-bumped but unpublished while #232 and #233 landed on top of it, and **P1–P4 all passed on exactly that state**. #234 fixes the record; this stops it recurring.

Verified in both directions against the live repo:

```
# on main, with the fold not yet merged
  P4 tarball contents:       OK (55 files)
release:precheck FAILED:
  x P5 CHANGELOG.md still has 7 line(s) under "## [Unreleased]" — move them into
    the version section being released, or they ship undocumented

# with the CHANGELOG from #234 applied
  P4 tarball contents:       OK (55 files)
  P5 [Unreleased] is empty:  OK
release:precheck PASSED
```

A missing `[Unreleased]` heading is treated as fine — nothing can be stranded under a section that doesn't exist.

## P4 — parse `npm pack --json` under npm 12

While testing P5, P4 failed outright:

```
x P4 could not inspect the tarball: Unexpected non-whitespace character after JSON at position 5545
```

npm ≤ 11 prints a JSON **array** of pack results; npm ≥ 12 prints an **object keyed by package name**. The old code anchored on the first `[`, which now finds the nested `"files": [` array, parses it, and then chokes on the trailing `"entryCount"` keys. P4 accepts both shapes now.

Worth being precise about the blast radius: `publish.yml` pins `npm install -g npm@11.13.0`, so this was **latent in CI**, not breaking releases today. It is active for anyone running the precheck locally on npm 12 — which is what Node 24.18.0 bundles — and it becomes active in CI the moment that pin moves. It fails closed (blocks the publish) rather than passing silently, which is the right direction, but the message points at the tarball rather than the parser.

## Verification

- `build:test`, `lint`, `format:check` pass
- `release:precheck` exercised against both changelog states shown above
- No source, test, or runtime change — release tooling only

## Note

Depends on nothing, but reads best after #234: until that merges, P5 will (correctly) fail on `main`.
