### PR TITLE
chore: update dependencies and devDependencies in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "4.2.0",
             "license": "MIT",
             "dependencies": {
-                "@napi-rs/canvas": "~1.0.3",
+                "@napi-rs/canvas": "~1.0.5",
                 "pdfjs-dist": "~6.2.108"
             },
             "bin": {
@@ -17,16 +17,16 @@
             },
             "devDependencies": {
                 "@eslint/js": "^10.0.1",
-                "@types/node": "^26.1.2",
-                "@typescript-eslint/eslint-plugin": "^8.65.0",
-                "@typescript-eslint/parser": "^8.65.0",
+                "@types/node": "^26.2.0",
+                "@typescript-eslint/eslint-plugin": "^8.67.0",
+                "@typescript-eslint/parser": "^8.67.0",
                 "@typescript/native": "npm:typescript@~7.0.2",
                 "@vitest/coverage-v8": "^4.1.10",
-                "eslint": "^10.8.0",
+                "eslint": "^10.8.1",
                 "husky": "^9.1.7",
                 "license-checker-rseidelsohn": "^5.0.1",
-                "lint-staged": "^17.2.0",
-                "png-visual-compare": "^6.2.0",
+                "lint-staged": "^17.3.0",
+                "png-visual-compare": "^6.3.0",
                 "prettier": "^3.9.6",
                 "rimraf": "^6.1.3",
                 "ts-node": "^10.9.2",
@@ -34,7 +34,7 @@
                 "vitest": "^4.1.10"
             },
             "engines": {
-                "node": ">=22.13.0 || >=24"
+                "node": ">=24"
             },
             "funding": {
                 "url": "https://buymeacoffee.com/dichovsky"
@@ -61,13 +61,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.7"
+                "@babel/types": "^7.29.8"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -77,9 +77,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -122,43 +122,6 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
-            }
-        },
-        "node_modules/@emnapi/core": {
-            "version": "2.0.0-alpha.3",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
-            "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "2.0.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "2.0.0-alpha.3",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
-            "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/wasi-threads": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
-            "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -401,9 +364,9 @@
             }
         },
         "node_modules/@napi-rs/canvas": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.3.tgz",
-            "integrity": "sha512-OlI657a5XXvKGFX7kNeIzJ8rO7IXt87Mqu2H8rXE46viAuOfum/JA7ysX7+eBhxNKznT+RCZh418mndlcFX3+w==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.5.tgz",
+            "integrity": "sha512-GaPlicMtnvgPr5SowFRprkEJicDSrV3qCq17U4jiF5u0kNORZo3IbdN2Bk4SfcZJAMYFHbMVJ81O3w21CYxazg==",
             "license": "MIT",
             "workspaces": [
                 "e2e/*"
@@ -416,23 +379,23 @@
                 "url": "https://github.com/sponsors/Brooooooklyn"
             },
             "optionalDependencies": {
-                "@napi-rs/canvas-android-arm64": "1.0.3",
-                "@napi-rs/canvas-darwin-arm64": "1.0.3",
-                "@napi-rs/canvas-darwin-x64": "1.0.3",
-                "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.3",
-                "@napi-rs/canvas-linux-arm64-gnu": "1.0.3",
-                "@napi-rs/canvas-linux-arm64-musl": "1.0.3",
-                "@napi-rs/canvas-linux-riscv64-gnu": "1.0.3",
-                "@napi-rs/canvas-linux-x64-gnu": "1.0.3",
-                "@napi-rs/canvas-linux-x64-musl": "1.0.3",
-                "@napi-rs/canvas-win32-arm64-msvc": "1.0.3",
-                "@napi-rs/canvas-win32-x64-msvc": "1.0.3"
+                "@napi-rs/canvas-android-arm64": "1.0.5",
+                "@napi-rs/canvas-darwin-arm64": "1.0.5",
+                "@napi-rs/canvas-darwin-x64": "1.0.5",
+                "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.5",
+                "@napi-rs/canvas-linux-arm64-gnu": "1.0.5",
+                "@napi-rs/canvas-linux-arm64-musl": "1.0.5",
+                "@napi-rs/canvas-linux-riscv64-gnu": "1.0.5",
+                "@napi-rs/canvas-linux-x64-gnu": "1.0.5",
+                "@napi-rs/canvas-linux-x64-musl": "1.0.5",
+                "@napi-rs/canvas-win32-arm64-msvc": "1.0.5",
+                "@napi-rs/canvas-win32-x64-msvc": "1.0.5"
             }
         },
         "node_modules/@napi-rs/canvas-android-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.3.tgz",
-            "integrity": "sha512-7kSCdUhoXiO+AaIMXdBGdtp6EctZNkmF62Rea/BmVQlwKaM3bBhOzyGUzxyxz9dv5vdBfpyAaxhSRSJF4kqK4A==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.5.tgz",
+            "integrity": "sha512-ZzDlpKQocwFfCwhMh17UWre6Qt5yZN3kNIJoUpGfRZqwDDZ164IKOsPOHsRd3d8Tuj5KM6bDjGuPmZxuPuG3NQ==",
             "cpu": [
                 "arm64"
             ],
@@ -450,9 +413,9 @@
             }
         },
         "node_modules/@napi-rs/canvas-darwin-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.3.tgz",
-            "integrity": "sha512-ds14V1BPagLszQyaDTeggny5fNeTCqsUQ5QhFj9VDxSEfzrVxXtdbR0LoFyKa0Siaaw8KvqSk4t7k/WoZJwvbg==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.5.tgz",
+            "integrity": "sha512-Hr8v6CA/TBe+OJOePdV3sXWxzQHQKfQsTKPbc8wG7iPqVeAx6MMdzKGXlYID6SVvpfwV/zqkvGcdImYWSlhrZg==",
             "cpu": [
                 "arm64"
             ],
@@ -470,9 +433,9 @@
             }
         },
         "node_modules/@napi-rs/canvas-darwin-x64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.3.tgz",
-            "integrity": "sha512-qof3LRAAycmkV2I1izZo9RoSHF8kCQr5O05sFwv0jK8rSdYV6KHVwimo6Qb7RxZj40WHKbLHm5JDaUF0o5XUAA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.5.tgz",
+            "integrity": "sha512-9BXlLHBXpYnK4jSae1MdFdyPq09Xi1I3PeCNpvRzqgmUUBhgJS7aC1z7SZEP8JUXDHtbfIrolCS3sFuT9IGP2A==",
             "cpu": [
                 "x64"
             ],
@@ -490,9 +453,9 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.3.tgz",
-            "integrity": "sha512-FU2kKZLmolHA9+KcUA+l1+xH3WTLUUTQDU/kLv9SEUr2TrRPu94aytOeizFJDHPs/QBcw4QL1mCQhetQXYBbag==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.5.tgz",
+            "integrity": "sha512-zEW4fgvtYsOJ/N56Us4TQPfaFrUf0shGr9CgGSj3GACc+NHfUM3ci0YF9xFTjwJWGDmaEhYPL6KqCfFCxwm/qg==",
             "cpu": [
                 "arm"
             ],
@@ -510,11 +473,14 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.3.tgz",
-            "integrity": "sha512-GVSjntxKeA+/y/ZKf1F+cmUw1WeIkE5aMRPqnZUlBTBvBcrvgWccJAWuYCKPX4QJQwZILIIwhgdAbl51yj6fpA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.5.tgz",
+            "integrity": "sha512-HFprwLspelJxCEtZvdMcz95Mwvfs63GzFVedLFmC/wslHnaOXhjXxgYxPCM/VdM4Jhx3CV4Lk0vVmh6hJv2etQ==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -530,11 +496,14 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.3.tgz",
-            "integrity": "sha512-J51oK/axyZ13kxycumSMfLiDZMdWdOVvqDFI28BpuViZHE3A0bQfr8B5vg8YnPEnqLD3BSn1hkdlh2buspEcNQ==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.5.tgz",
+            "integrity": "sha512-FNMGFAx8DvtDwlLfWyBJ+oQjgPXoIAqCnNTJYqtJCFRwwzK3AyAe5B1Ll3NZ6hcOzqw7HylZsq4nQxVyPCQX1Q==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -550,11 +519,14 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.3.tgz",
-            "integrity": "sha512-CtQgQjoVTX67jS9XuCTtJ40Sl7wRLMguoFnnGnfDmCWf7kzKFZVwj5ynqUOIGKFMSB61ZCuQlwPvVNxYTTseaw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.5.tgz",
+            "integrity": "sha512-2vd5v8Lui+37Hh/spITKIvTT384ip4dnUc5XBn0E+sMNS4b7au7IswyT5YDG2udPTjSh/eLUs3sGuB5YHooFOA==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -570,11 +542,14 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.3.tgz",
-            "integrity": "sha512-jtfzAHFp+FRaR7zGT4jyCe6wUgAG/dVb5A4Apd8FY9jKarntDfUAlJXscugiH7ZF5kKnu7/lHFk9LaDPcrGEVQ==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.5.tgz",
+            "integrity": "sha512-iQIPy+Uey0expZTOszLri5n8rY7x4WUpMaY82mcXNIgbil30iHvc01OsiizhZC1KQHTK90RFMFWSpwFU+ON3aA==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -590,11 +565,14 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-x64-musl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.3.tgz",
-            "integrity": "sha512-xTzaUCKUHTY4bCGadeeRZggbRVbGUT1petg7Z8r9AJR2+D9Bqu6nQAgqBGC6D47tA70LjaaaLTrJ7wNY1T74dg==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.5.tgz",
+            "integrity": "sha512-Npthji25t7FUqIAKsoEkFS0qY5CYVkHjvI3tuZjDTG92wX8g4dst+Lfb4hhubdqPazlDcIwalPzInsFCtf3FFg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -610,9 +588,9 @@
             }
         },
         "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.3.tgz",
-            "integrity": "sha512-ktVLuBkI6QVOm5BwO/WbdGwxgeetAMJa7TTmR8qBarXF0OU2NKjvjUtPJAl2y8t+zBRczJl/1VOl9gua6WcK2g==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.5.tgz",
+            "integrity": "sha512-bi+JsdCdbfVJDoAQybTYmkLKwh1xpYpptg5j/BNr2BB56u4/R26jrVvtjqff+CxYMXV6Kz1/jeDVhZCuj6bDng==",
             "cpu": [
                 "arm64"
             ],
@@ -630,9 +608,9 @@
             }
         },
         "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.3.tgz",
-            "integrity": "sha512-SGhlQ8bDjL1Cz2KnsKMasr/5sTcwG/SZkB6WCJxLsmSm/3aS2C+3p39bA7iZ2/94+NkVDySZfbiGoaSZSFHYxA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.5.tgz",
+            "integrity": "sha512-KQQwG9/sBmcGxqaLFIQf+k2OefREGoyEaIBmRuTM8bUuFKOEE9Xk5pel90hE6pmBwk/vo4RB0OdX+FxobJGMFw==",
             "cpu": [
                 "x64"
             ],
@@ -647,28 +625,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
-            "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.3"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^2.0.0-alpha.3",
-                "@emnapi/runtime": "^2.0.0-alpha.3"
             }
         },
         "node_modules/@npmcli/agent": {
@@ -991,9 +947,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.139.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+            "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1001,9 +957,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+            "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
             "cpu": [
                 "arm64"
             ],
@@ -1018,9 +974,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+            "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
             "cpu": [
                 "arm64"
             ],
@@ -1035,9 +991,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+            "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
             "cpu": [
                 "x64"
             ],
@@ -1052,9 +1008,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+            "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
             "cpu": [
                 "x64"
             ],
@@ -1069,9 +1025,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+            "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
             "cpu": [
                 "arm"
             ],
@@ -1086,13 +1042,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+            "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1103,13 +1062,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+            "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1120,13 +1082,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+            "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1137,13 +1102,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+            "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1154,13 +1122,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+            "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1171,13 +1142,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+            "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1188,9 +1162,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+            "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
             "cpu": [
                 "arm64"
             ],
@@ -1204,63 +1178,10 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-            "cpu": [
-                "wasm32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.11.1",
-                "@emnapi/runtime": "1.11.1",
-                "@napi-rs/wasm-runtime": "^1.1.6"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+            "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
             "cpu": [
                 "arm64"
             ],
@@ -1275,9 +1196,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+            "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
             "cpu": [
                 "x64"
             ],
@@ -1437,17 +1358,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/@tybys/wasm-util": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@types/chai": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1488,9 +1398,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.1.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-            "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+            "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1498,17 +1408,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-            "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+            "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/type-utils": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/type-utils": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -1521,22 +1431,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.65.0",
+                "@typescript-eslint/parser": "^8.67.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-            "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+            "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1552,14 +1462,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+            "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.65.0",
-                "@typescript-eslint/types": "^8.65.0",
+                "@typescript-eslint/tsconfig-utils": "^8.67.0",
+                "@typescript-eslint/types": "^8.67.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1574,14 +1484,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-            "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+            "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0"
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1592,9 +1502,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+            "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1609,15 +1519,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-            "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+            "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -1634,9 +1544,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-            "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+            "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1648,16 +1558,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+            "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.65.0",
-                "@typescript-eslint/tsconfig-utils": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
+                "@typescript-eslint/project-service": "8.67.0",
+                "@typescript-eslint/tsconfig-utils": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -1676,16 +1586,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+            "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0"
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1700,13 +1610,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-            "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+            "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/types": "8.67.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -2421,9 +2331,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2650,9 +2560,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.8.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-            "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+            "version": "10.8.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+            "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -2951,9 +2861,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
-            "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+            "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
             "dev": true,
             "license": "ISC"
         },
@@ -3166,9 +3076,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
-            "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+            "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3511,6 +3421,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -3532,6 +3445,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -3553,6 +3469,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -3574,6 +3493,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -3630,9 +3552,9 @@
             }
         },
         "node_modules/lint-staged": {
-            "version": "17.2.0",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.2.0.tgz",
-            "integrity": "sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A==",
+            "version": "17.3.0",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
+            "integrity": "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3697,14 +3619,14 @@
             }
         },
         "node_modules/magicast": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-            "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+            "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "source-map-js": "^1.2.1"
             }
         },
@@ -3925,9 +3847,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {
@@ -4376,9 +4298,9 @@
             }
         },
         "node_modules/png-visual-compare": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/png-visual-compare/-/png-visual-compare-6.2.0.tgz",
-            "integrity": "sha512-yEYZR0SEPwSUhxvuIfv1TqvvknsEY9vRV2QE2RGQ/juF2a5qXJLo0ep3GWs6YMB4jMJiZaPSeEIs0OD3vFFd+Q==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/png-visual-compare/-/png-visual-compare-6.3.0.tgz",
+            "integrity": "sha512-W/6s6E3g5v46Wb+mWXMjBTU5ZLVUM7Zm0nUok8VjumcxU8worT3RiH30RQs0E8NnSsVDr9Qex3HlzHb0gqmnXQ==",
             "dev": true,
             "license": "MIT",
             "os": [
@@ -4420,9 +4342,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.24",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
-            "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "dev": true,
             "funding": [
                 {
@@ -4440,7 +4362,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.16",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -4449,9 +4371,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4569,13 +4491,13 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+            "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.139.0",
+                "@oxc-project/types": "=0.143.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -4585,21 +4507,20 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.1.5",
-                "@rolldown/binding-darwin-arm64": "1.1.5",
-                "@rolldown/binding-darwin-x64": "1.1.5",
-                "@rolldown/binding-freebsd-x64": "1.1.5",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-                "@rolldown/binding-linux-arm64-musl": "1.1.5",
-                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-                "@rolldown/binding-linux-x64-gnu": "1.1.5",
-                "@rolldown/binding-linux-x64-musl": "1.1.5",
-                "@rolldown/binding-openharmony-arm64": "1.1.5",
-                "@rolldown/binding-wasm32-wasi": "1.1.5",
-                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-                "@rolldown/binding-win32-x64-msvc": "1.1.5"
+                "@rolldown/binding-android-arm64": "1.2.3",
+                "@rolldown/binding-darwin-arm64": "1.2.3",
+                "@rolldown/binding-darwin-x64": "1.2.3",
+                "@rolldown/binding-freebsd-x64": "1.2.3",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+                "@rolldown/binding-linux-arm64-musl": "1.2.3",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+                "@rolldown/binding-linux-x64-gnu": "1.2.3",
+                "@rolldown/binding-linux-x64-musl": "1.2.3",
+                "@rolldown/binding-openharmony-arm64": "1.2.3",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+                "@rolldown/binding-win32-x64-msvc": "1.2.3"
             }
         },
         "node_modules/safer-buffer": {
@@ -4910,9 +4831,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+            "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5023,14 +4944,6 @@
                 }
             }
         },
-        "node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
-        },
         "node_modules/tuf-js": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
@@ -5125,16 +5038,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+            "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "lightningcss": "^1.32.0",
+                "lightningcss": "^1.33.0",
                 "picomatch": "^4.0.5",
-                "postcss": "^8.5.17",
-                "rolldown": "~1.1.5",
+                "postcss": "^8.5.25",
+                "rolldown": "~1.2.1",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -5151,7 +5064,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.3.0",
+                "@vitejs/devtools": "^0.4.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -78,33 +78,32 @@
         ]
     },
     "dependencies": {
-        "@napi-rs/canvas": "~1.0.3",
+        "@napi-rs/canvas": "~1.0.5",
         "pdfjs-dist": "~6.2.108"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^26.1.2",
-        "@typescript-eslint/eslint-plugin": "^8.65.0",
-        "@typescript-eslint/parser": "^8.65.0",
+        "@types/node": "^26.2.0",
+        "@typescript-eslint/eslint-plugin": "^8.67.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "@typescript/native": "npm:typescript@~7.0.2",
         "@vitest/coverage-v8": "^4.1.10",
-        "eslint": "^10.8.0",
+        "eslint": "^10.8.1",
         "husky": "^9.1.7",
         "license-checker-rseidelsohn": "^5.0.1",
-        "lint-staged": "^17.2.0",
-        "png-visual-compare": "^6.2.0",
+        "lint-staged": "^17.3.0",
+        "png-visual-compare": "^6.3.0",
         "prettier": "^3.9.6",
         "rimraf": "^6.1.3",
         "ts-node": "^10.9.2",
         "typescript": "npm:@typescript/typescript6@~6.0.2",
         "vitest": "^4.1.10"
     },
-    "overrides": {
-        "brace-expansion": "^5.0.8"
-    },
-    "packageManager": "npm@11.13.0",
     "engines": {
-        "node": ">=22.13.0 || >=24"
+        "node": ">=24"
     },
-    "_packageFormatNote": "CJS-only — nodenext TS with .js specifiers is compatible."
+    "_packageFormatNote": "CJS-only — nodenext TS with .js specifiers is compatible.",
+    "allowScripts": {
+        "fsevents@2.3.3": true
+    }
 }


### PR DESCRIPTION
- Bump @napi-rs/canvas from ~1.0.3 to ~1.0.5
- Update @types/node from ^26.1.2 to ^26.2.0
- Upgrade @typescript-eslint/eslint-plugin and @typescript-eslint/parser from ^8.65.0 to ^8.67.0
- Increment eslint from ^10.8.0 to ^10.8.1
- Update lint-staged from ^17.2.0 to ^17.3.0
- Upgrade png-visual-compare from ^6.2.0 to ^6.3.0
- Change node engine requirement from ">=22.13.0 || >=24" to ">=24"
- Add allowScripts for fsevents@2.3.3