### PR TITLE
chore: release v4.2.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+
+*.pdf binary
+*.png binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+# eol=lf normalizes anything git's heuristic classifies as text. Add a `binary` line for any
+# new fixture format git might misdetect as text (mostly-ASCII content, e.g. *.pdf below).
 * text=auto eol=lf
 
 *.pdf binary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,11 @@ jobs:
               with:
                   node-version: '24'
                   cache: 'npm'
+            # png-visual-compare is a pure-JavaScript test helper whose package metadata limits
+            # installation to Darwin/Linux. Override that development-only platform guard so the
+            # real Windows native dependency and render paths can be exercised by the full suite.
             - name: Install dependencies
-              run: npm ci
+              run: npm ci --force
             - name: Audit dependencies
               run: npm audit --audit-level=high
             - name: Validate native Windows install and rendering

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests on push
 on:
     push:
+        branches: [main]
     pull_request:
 permissions:
     contents: read
@@ -45,26 +46,27 @@ jobs:
               with:
                   node-version: '24'
                   cache: 'npm'
+            # An unforced install of the runtime tree fails EBADPLATFORM/EBADENGINE exactly like a
+            # consumer's `npm install pdf-to-png-converter` would, preserving the platform guard
+            # that the forced development install below has to bypass.
+            - name: Validate production dependency platform support
+              run: npm ci --omit=dev
             # png-visual-compare is a pure-JavaScript test helper whose package metadata limits
             # installation to Darwin/Linux. Override that development-only platform guard so the
-            # real Windows native dependency and render paths can be exercised by the full suite.
+            # real Windows native dependency and render paths can be exercised by the suite.
             - name: Install dependencies
               run: npm ci --force
-            - name: Audit dependencies
-              run: npm audit --audit-level=high
             - name: Validate native Windows install and rendering
-              run: npm run check
-    # Keep the stable status context required by main's branch-protection rule while the platform
-    # jobs expose each supported Node.js line and the native Windows smoke separately.
+              run: npm run test:fast
+    # Keep the stable status context required by main's branch-protection rule while the test
+    # matrix exposes each supported Node.js line separately. The Windows smoke publishes its own
+    # non-required status: Windows support is best-effort and must not block merges.
     ubuntu:
         if: ${{ always() }}
-        needs: [test, windows]
+        needs: test
         runs-on: ubuntu-latest
         steps:
-            - name: Require successful platform checks
+            - name: Require successful test matrix
               env:
                   MATRIX_RESULT: ${{ needs.test.result }}
-                  WINDOWS_RESULT: ${{ needs.windows.result }}
-              run: |
-                  test "$MATRIX_RESULT" = success
-                  test "$WINDOWS_RESULT" = success
+              run: test "$MATRIX_RESULT" = success

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,17 +59,15 @@ jobs:
               run: npm ci --force
             - name: Validate native Windows install and rendering
               run: npm run test:fast
-    # Keep the stable status context required by main's branch-protection rule while the platform
-    # jobs expose each supported Node.js line and the native Windows smoke separately.
+    # Keep the stable status context required by main's branch-protection rule while the test
+    # matrix exposes each supported Node.js line separately. The Windows smoke publishes its own
+    # non-required status: Windows support is best-effort and must not block merges.
     ubuntu:
         if: ${{ always() }}
-        needs: [test, windows]
+        needs: test
         runs-on: ubuntu-latest
         steps:
-            - name: Require successful platform checks
+            - name: Require successful test matrix
               env:
                   MATRIX_RESULT: ${{ needs.test.result }}
-                  WINDOWS_RESULT: ${{ needs.windows.result }}
-              run: |
-                  test "$MATRIX_RESULT" = success
-                  test "$WINDOWS_RESULT" = success
+              run: test "$MATRIX_RESULT" = success

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,35 @@ jobs:
                   name: coverage-node-${{ matrix.node-version }}
                   path: test-results/coverage/
                   if-no-files-found: warn
-    # Keep the stable status context required by main's branch-protection rule while the test
-    # matrix exposes each supported Node.js line separately.
+    windows:
+        name: windows (24)
+        runs-on: windows-latest
+        timeout-minutes: 30
+        steps:
+            - name: Checkout
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - name: Setup Node.js
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: '24'
+                  cache: 'npm'
+            - name: Install dependencies
+              run: npm ci
+            - name: Audit dependencies
+              run: npm audit --audit-level=high
+            - name: Validate native Windows install and rendering
+              run: npm run check
+    # Keep the stable status context required by main's branch-protection rule while the platform
+    # jobs expose each supported Node.js line and the native Windows smoke separately.
     ubuntu:
         if: ${{ always() }}
-        needs: test
+        needs: [test, windows]
         runs-on: ubuntu-latest
         steps:
-            - name: Require successful test matrix
+            - name: Require successful platform checks
               env:
                   MATRIX_RESULT: ${{ needs.test.result }}
-              run: test "$MATRIX_RESULT" = success
+                  WINDOWS_RESULT: ${{ needs.windows.result }}
+              run: |
+                  test "$MATRIX_RESULT" = success
+                  test "$WINDOWS_RESULT" = success

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,10 @@ jobs:
                   cache: 'npm'
             # An unforced install of the runtime tree fails EBADPLATFORM/EBADENGINE exactly like a
             # consumer's `npm install pdf-to-png-converter` would, preserving the platform guard
-            # that the forced development install below has to bypass.
+            # that the forced development install below has to bypass. --ignore-scripts skips this
+            # repo's husky `prepare` hook (a dev dependency consumers never run).
             - name: Validate production dependency platform support
-              run: npm ci --omit=dev
+              run: npm ci --omit=dev --ignore-scripts
             # png-visual-compare is a pure-JavaScript test helper whose package metadata limits
             # installation to Darwin/Linux. Override that development-only platform guard so the
             # real Windows native dependency and render paths can be exercised by the suite.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,15 +59,17 @@ jobs:
               run: npm ci --force
             - name: Validate native Windows install and rendering
               run: npm run test:fast
-    # Keep the stable status context required by main's branch-protection rule while the test
-    # matrix exposes each supported Node.js line separately. The Windows smoke publishes its own
-    # non-required status: Windows support is best-effort and must not block merges.
+    # Keep the stable status context required by main's branch-protection rule while the platform
+    # jobs expose each supported Node.js line and the native Windows smoke separately.
     ubuntu:
         if: ${{ always() }}
-        needs: test
+        needs: [test, windows]
         runs-on: ubuntu-latest
         steps:
-            - name: Require successful test matrix
+            - name: Require successful platform checks
               env:
                   MATRIX_RESULT: ${{ needs.test.result }}
-              run: test "$MATRIX_RESULT" = success
+                  WINDOWS_RESULT: ${{ needs.windows.result }}
+              run: |
+                  test "$MATRIX_RESULT" = success
+                  test "$WINDOWS_RESULT" = success

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
 node_modules/*
 test-results/*
-.gitattributes

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules/*
 test-results/*
+.gitattributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.1] — 2026-08-24
+
 ### Changed
 
 - Consolidated conversion into one canonical `pdfToPng()` path. Option normalization, page planning, bounded main-thread scheduling, mode selection, output finalization, and document teardown now live together; the CLI delegates to that public API instead of a normalized internal core. The public package exports and option/result behavior are unchanged.
@@ -19,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded regression coverage for worker startup, dispatch, fatal ordering, queued and malformed responses, growing file inputs, non-`Error` CLI failures, portable pdf.js factory URLs, Windows output-path escape detection, and missing renderer content in file mode. The clean suite reaches 99.78% statements, 99.68% branches, 100% functions, and 99.77% lines.
 - Refreshed dependency ranges, including `@napi-rs/canvas` from `~1.0.3` to `~1.0.8`, Vitest and `@vitest/coverage-v8` from `^4.1.10` to `^4.1.11`, ESLint from `^10.8.0` to `^10.9.1`, and `@types/node` from `^26.1.2` to `^26.3.0`, plus compatible typescript-eslint, lint-staged, and visual-comparison tooling updates. The publish workflow now pins npm 12.0.2.
 - Removed the obsolete `brace-expansion` override after refreshing the audited lockfile, moved the publisher's npm pin from package metadata to the workflow, and recorded the permitted `fsevents@2.3.3` lifecycle script in `allowScripts`.
-- CI now validates the supported Node.js floor (22.13) as well as the Node.js 24 development and publishing line.
+- CI now validates the supported Node.js floor (22.13) as well as the Node.js 24 development and publishing line, including a Node.js 24 Windows native smoke run.
 
 ### Fixed
 
@@ -236,7 +238,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File path and `ArrayBuffer` input support
 - `outputFolder`, `viewportScale`, `pdfFilePassword`, `disableFontFace`, `useSystemFonts`, `enableXfa` options
 
-[Unreleased]: https://github.com/dichovsky/pdf-to-png-converter/compare/v4.2.0...HEAD
+[Unreleased]: https://github.com/dichovsky/pdf-to-png-converter/compare/v4.2.1...HEAD
+[4.2.1]: https://github.com/dichovsky/pdf-to-png-converter/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/dichovsky/pdf-to-png-converter/compare/v4.1.1...v4.2.0
 [4.1.1]: https://github.com/dichovsky/pdf-to-png-converter/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/dichovsky/pdf-to-png-converter/compare/8368a905c5c7c8ab71c8d04be8745da51cd4db05...v4.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.2.1] — 2026-08-24
+## [4.2.1] — 2026-08-25
 
 ### Changed
 

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -24,8 +24,10 @@ All items are release blockers:
 - `npm run build` passes and produces the required CommonJS library, declarations, CLI, and worker entry in `out/`.
 - `npm run release:precheck` passes after the version/changelog cut, including the registry-version and tarball-content checks.
 - A normal render, metadata-only conversion, file output, CLI invocation, and worker-thread render remain covered by the automated suite.
-- The Node.js 22.13 and 24 CI matrix passes on the release commit, confirming the patch preserves the published runtime floor. Because `@napi-rs/canvas` is native and the publish job runs on Linux, retain the local macOS render result and obtain a Windows smoke result before publishing if a Windows runner is available.
+- The Node.js 22.13 and 24 CI matrix passes on the release commit, confirming the patch preserves the published runtime floor. Retain the local macOS render result because `@napi-rs/canvas` is native and the publish job runs on Linux.
 - Review confirms that `[Unreleased]` contains no breaking public API change. If one is found, stop and choose the appropriate SemVer version before tagging.
+
+The Node.js 24 Windows smoke is informational. Windows support is best-effort, so its result does not block merge or publication.
 
 ## Cut sequence
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pdf-to-png-converter",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pdf-to-png-converter",
-            "version": "4.2.0",
+            "version": "4.2.1",
             "license": "MIT",
             "dependencies": {
                 "@napi-rs/canvas": "~1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pdf-to-png-converter",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "description": "Node.js utility to convert PDF file/buffer pages to PNG files/buffers. No build-time compilation required — pre-built native binaries included for all major platforms.",
     "keywords": [
         "pdf",


### PR DESCRIPTION
## Summary

- bump package and lockfile metadata to `4.2.1`
- move the complete `[Unreleased]` changelog into the `2026-08-25` v4.2.1 section and advance comparison links
- validate Node.js 22.13 and 24 on Ubuntu behind the stable required `ubuntu` aggregate
- publish a separate informational Node.js 24 Windows smoke that checks an unforced production install and the native test suite; Windows support remains best-effort and non-blocking
- normalize tracked text to LF while preserving PNG/PDF fixtures as binary

## Release gates completed locally

- `npm ci`
- direct dependencies current (`npm-check-updates` and `npm outdated --depth=0`)
- `npm audit` and `npm audit --omit=dev`: zero vulnerabilities
- `npm run check`: 45 files; 294 passed, 2 skipped; 99.78% statements, 99.68% branches, 100% functions, 99.77% lines
- `npm run build`
- `RELEASE_TAG=v4.2.1 npm run release:precheck`: P1-P5 passed; 25-file tarball

Release review feedback has been incorporated. `v4.2.1` remains unpublished and no tag or GitHub Release has been created.

## After merge

Tag the exact merge SHA, create and verify a **draft** GitHub Release, then obtain explicit confirmation before publishing it. Publishing the non-prerelease release triggers the OIDC npm publish workflow and is intentionally outside this PR.