### PR TITLE
chore: upgrade pdfjs-dist to 6.3.289

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ The source tree contains 11 TypeScript modules:
 | ------------------------- | ----------------------------------------------------------------------------------------- |
 | `src/index.ts`            | Public re-exports only                                                                    |
 | `src/types.ts`            | Public options, output union, rotation, and verbosity                                     |
-| `src/const.ts`            | Defaults and input/concurrency/canvas limits                                              |
+| `src/const.ts`            | Defaults, input/concurrency/canvas limits, pipeline window, pdf.js asset paths            |
 | `src/pdfToPng.ts`         | Validation, planning, scheduling, mode selection, output finalization, document lifecycle |
 | `src/pdfInput.ts`         | Input normalization, ownership, one-handle bounded file reads                             |
 | `src/pdfjsLoader.ts`      | Cached dynamic pdf.js import, init parameters, load cleanup                               |
@@ -129,6 +129,8 @@ Vitest has a 180-second timeout. V8 coverage thresholds are 98% for statements, 
 
 Fixtures live in `test-data/`; generated output and coverage live in `test-results/`. Prefer focused tests while iterating, then run `npm run check`.
 
+`__tests__/pdfjs.assets.test.ts` exact-checks the installed `cmaps` and `standard_fonts` layout against `__tests__/test-data-constants.ts`. For `pdfjs-dist` upgrades, review asset-list changes explicitly, do not auto-refresh golden PNGs, and run the real-worker parity suite.
+
 High-value regression areas:
 
 - caller-buffer ownership and cross-realm input shapes
@@ -137,6 +139,7 @@ High-value regression areas:
 - metadata/render dimension parity and cleanup on every failure hop
 - result order and deterministic failures in default, parallel, and worker modes
 - worker document reuse, crashes, output-finalizer failures, and complete termination
+- pdf.js import/type compatibility, installed asset layout, golden rendering, and main/worker byte parity
 - CLI metadata JSON, required output-folder policy, silent behavior, and packaging/version errors
 
 ## Benchmark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded `pdfjs-dist` from `~6.2.108` to `~6.3.289`. The project's public API, defaults, `legacy/build/pdf.mjs` import, worker integration, and `cmaps` / `standard_fonts` asset paths are unchanged. Upstream 6.3 includes rendering changes affecting fonts, annotations, XFA, and JPEG handling, plus updates to the bundled Liberation-font and pdf.js qcms license files. Rendered PNG output for the existing fixtures is unchanged — the visual-comparison suites pass against the existing reference images.
+- Added an exact package-layout regression for the CMaps and standard fonts consumed from `pdfjs-dist`, so future dependency updates must explicitly review asset additions, removals, and renames.
+- Refreshed the development-only `@types/node` range from `^26.3.0` to `^26.4.0` and `lint-staged` from `^17.3.0` to `^17.4.1`.
+
 ## [4.2.1] — 2026-08-25
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The current source tree has 11 modules:
 - `src/pageRenderWorker.ts` — compiled worker entry; lazy document load and page rendering inside each worker.
 - `src/cli.ts` — CLI parsing and policy; delegates to the public `pdfToPng` function.
 - `src/types.ts` — public option and output types plus `VerbosityLevel`.
-- `src/const.ts` — defaults and resource/concurrency limits.
+- `src/const.ts` — defaults, resource/concurrency limits, pipeline window, and pdf.js asset paths.
 - `src/index.ts` — public re-exports only.
 
 Keep this consolidated ownership. Split out another seam only when a new independent implementation or lifecycle boundary actually needs it. See `docs/ARCHITECTURE.md` for the full runtime and ownership model.
@@ -94,6 +94,8 @@ Hard limits are also centralized in `src/const.ts`:
 Vitest uses a 180-second timeout and enforces 98% V8 coverage for statements, lines, functions, and branches. `src/pageRenderWorker.ts` is exercised both through real-worker integration and in-process protocol tests so its branches remain part of the aggregate gate.
 
 Fixtures live in `test-data/`; generated output and coverage live in `test-results/`. Worker integration tests compile `out/pageRenderWorker.js` directly before spawning real workers.
+
+`__tests__/pdfjs.assets.test.ts` exact-checks the installed `cmaps` and `standard_fonts` layout against `__tests__/test-data-constants.ts`. For `pdfjs-dist` upgrades, review asset-list changes explicitly, keep existing golden PNGs unchanged unless a rendering change is understood and intentional, and run the real-worker parity suite.
 
 Prefer focused tests while iterating, then run `npm run check`. Do not use `npm run build` inside a running test suite because its `prebuild` hook deletes `test-results/` and `out/`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,16 @@ If `build:strict` fails because of an upstream type, suppress on the line immedi
 
 Do not work around `build:strict` failures by adding `continue-on-error` to the workflow or `|| true` to the script.
 
+## pdf.js dependency upgrades
+
+`pdfjs-dist` is both a type boundary and the rendering engine, so an upgrade must pass more than the package-manager checks:
+
+- `__tests__/pdfjs.assets.test.ts` exact-checks the installed `cmaps` and `standard_fonts` directory contents against `__tests__/test-data-constants.ts`. Update those lists only after reviewing the upstream package-layout diff; added files are deliberately review-gated rather than accepted as a subset.
+- Run the visual-comparison suites against the existing reference PNGs and inspect `git status --short -- test-data` afterward. Do not create or refresh golden files merely to make an upgrade pass.
+- Run the real worker-thread integration tests so the CommonJS-to-legacy-ESM import and per-worker pdf.js lifecycle stay covered.
+- Finish from a clean install with `npm run check`, `npm run build`, `npm audit --audit-level=high`,
+  `npm audit --omit=dev --audit-level=high`, and `npm pack --dry-run --ignore-scripts --json`.
+
 ## Coding Conventions
 
 - **Language:** TypeScript (strict mode). All source lives under `src/`.

--- a/__tests__/pdfjs.assets.test.ts
+++ b/__tests__/pdfjs.assets.test.ts
@@ -1,0 +1,15 @@
+import { readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { expect, test } from 'vitest';
+import { CMAP_RELATIVE_URL, STANDARD_FONTS_RELATIVE_URL } from '../src/const.js';
+import { STANDARD_CMAPS, STANDARD_FONTS } from './test-data-constants.js';
+
+const ASSET_DIRECTORIES = [
+    { label: 'standard-font', relativePath: STANDARD_FONTS_RELATIVE_URL, expectedFiles: STANDARD_FONTS },
+    { label: 'CMap', relativePath: CMAP_RELATIVE_URL, expectedFiles: STANDARD_CMAPS },
+] as const;
+
+test.each(ASSET_DIRECTORIES)('pdfjs-dist ships the expected $label assets', ({ relativePath, expectedFiles }) => {
+    const actualFiles = readdirSync(resolve(relativePath)).sort();
+    expect(actualFiles).toEqual([...expectedFiles].sort());
+});

--- a/__tests__/test-data-constants.ts
+++ b/__tests__/test-data-constants.ts
@@ -1,6 +1,6 @@
 /**
  * Filenames of the standard font files shipped with `pdfjs-dist` (Foxit and Liberation fonts).
- * Used by tests to verify that the expected font assets are present after installation.
+ * Exact-checked by pdfjs.assets.test.ts so dependency upgrades require an explicit layout review.
  */
 export const STANDARD_FONTS = [
     'FoxitDingbats.pfb',
@@ -25,7 +25,7 @@ export const STANDARD_FONTS = [
  * Filenames of the pre-packed character map (CMap) files shipped with `pdfjs-dist`.
  * CMaps are required for correct text extraction and rendering of CJK (Chinese, Japanese, Korean)
  * and other multi-byte character encodings in PDFs.
- * Used by tests to verify that the expected CMap assets are present after installation.
+ * Exact-checked by pdfjs.assets.test.ts so dependency upgrades require an explicit layout review.
  */
 export const STANDARD_CMAPS = [
     '78-EUC-H.bcmap',

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,5 +119,7 @@ The realpath comparison does not atomically bind the write to a directory inode.
 - Runtime requirement: Node.js 22.13 or newer; `.nvmrc` uses Node.js 24 and CI tests Node.js 22.13 and 24.
 - Package format: CommonJS, compiled from `.ts` to `out/` with `.js` relative import specifiers.
 - `npm test` runs Vitest with coverage only and enforces 98% thresholds for statements, lines, functions, and branches across all production modules.
+- `npm run build:strict` checks the upstream `pdfjs-dist` / `@napi-rs/canvas` declaration boundary with `skipLibCheck: false`.
+- `__tests__/pdfjs.assets.test.ts` exact-checks the installed pdf.js CMap and standard-font layout; golden-image and real-worker tests cover rendered output and main/worker parity.
 - `npm run check` is the explicit CI/prepublish gate: clean, normal and strict type-checks, formatting, lint, production-license validation, and tests.
 - `npm run build` performs the publishable production compile after cleaning `out/` and `test-results/`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
             "license": "MIT",
             "dependencies": {
                 "@napi-rs/canvas": "~1.0.8",
-                "pdfjs-dist": "~6.2.108"
+                "pdfjs-dist": "~6.3.289"
             },
             "bin": {
                 "pdf-to-png-converter": "out/cli.js"
             },
             "devDependencies": {
                 "@eslint/js": "^10.0.1",
-                "@types/node": "^26.3.0",
+                "@types/node": "^26.4.0",
                 "@typescript-eslint/eslint-plugin": "^8.68.0",
                 "@typescript-eslint/parser": "^8.68.0",
                 "@typescript/native": "npm:typescript@~7.0.2",
@@ -25,7 +25,7 @@
                 "eslint": "^10.9.1",
                 "husky": "^9.1.7",
                 "license-checker-rseidelsohn": "^5.0.1",
-                "lint-staged": "^17.3.0",
+                "lint-staged": "^17.4.1",
                 "png-visual-compare": "^6.3.0",
                 "prettier": "^3.9.6",
                 "rimraf": "^6.1.3",
@@ -1415,9 +1415,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
-            "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+            "version": "26.4.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+            "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3583,15 +3583,15 @@
             }
         },
         "node_modules/lint-staged": {
-            "version": "17.3.0",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
-            "integrity": "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==",
+            "version": "17.4.1",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.4.1.tgz",
+            "integrity": "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "picomatch": "^4.0.5",
+                "picomatch": "^4.0.7",
                 "string-argv": "^0.3.2",
-                "tinyexec": "^1.2.4"
+                "tinyexec": "^1.3.0"
             },
             "bin": {
                 "lint-staged": "bin/lint-staged.js"
@@ -4291,9 +4291,9 @@
             "license": "MIT"
         },
         "node_modules/pdfjs-dist": {
-            "version": "6.2.108",
-            "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.2.108.tgz",
-            "integrity": "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==",
+            "version": "6.3.289",
+            "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.3.289.tgz",
+            "integrity": "sha512-ZHjSVpDa3D6izMq8/04lvkhkATUmL9px6ChPaXc1k6nU2Mrhlg1/7F0bdUqCwUjw3NsPTfPZsMDUU6ZIcRaeQw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=22.13.0 || >=24"

--- a/package.json
+++ b/package.json
@@ -77,11 +77,11 @@
     },
     "dependencies": {
         "@napi-rs/canvas": "~1.0.8",
-        "pdfjs-dist": "~6.2.108"
+        "pdfjs-dist": "~6.3.289"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^26.3.0",
+        "@types/node": "^26.4.0",
         "@typescript-eslint/eslint-plugin": "^8.68.0",
         "@typescript-eslint/parser": "^8.68.0",
         "@typescript/native": "npm:typescript@~7.0.2",
@@ -89,7 +89,7 @@
         "eslint": "^10.9.1",
         "husky": "^9.1.7",
         "license-checker-rseidelsohn": "^5.0.1",
-        "lint-staged": "^17.3.0",
+        "lint-staged": "^17.4.1",
         "png-visual-compare": "^6.3.0",
         "prettier": "^3.9.6",
         "rimraf": "^6.1.3",

--- a/src/pageRenderer.ts
+++ b/src/pageRenderer.ts
@@ -180,7 +180,7 @@ export async function renderPdfPage(
             throw new Error('pdf.js canvas factory returned a null canvas or context.');
         }
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore — upstream pdfjs-dist@~6.2.x expects DOM CanvasRenderingContext2D, but @napi-rs/canvas exposes SKRSContext2D here. @ts-ignore (not @ts-expect-error) is required because build:test runs with skipLibCheck:true, which hides this error and would make @ts-expect-error report as unused.
+        // @ts-ignore — upstream pdfjs-dist@~6.3.x expects DOM CanvasRenderingContext2D, but @napi-rs/canvas exposes SKRSContext2D here. @ts-ignore (not @ts-expect-error) is required because build:test runs with skipLibCheck:true, which hides this error and would make @ts-expect-error report as unused.
         await page.render({ canvasContext: context, viewport, canvas }).promise;
         return {
             // Async encode() runs on the libuv threadpool (byte-identical to the synchronous


### PR DESCRIPTION
## Summary

- upgrade `pdfjs-dist` from `~6.2.108` to `~6.3.289` and synchronize the lockfile
- add an exact regression test for the installed pdf.js CMap and standard-font layouts
- document the dependency-upgrade validation workflow and keep compatibility comments current
- include the pending development-only `@types/node` and `lint-staged` refreshes in the synchronized lockfile and changelog

## Validation

- `npm ci`
- `npm run check` — 46 files passed, 296 tests passed, 2 skipped
- `npm run build`
- `npm audit --audit-level=high`
- `npm audit --omit=dev --audit-level=high`
- `npm ls pdfjs-dist @napi-rs/canvas --depth=1`
- `npm pack --dry-run --ignore-scripts --json`
- visual fixtures unchanged and fresh independent review found no issues